### PR TITLE
Add missing settings category

### DIFF
--- a/client/ayon_deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/client/ayon_deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -37,6 +37,7 @@ class AfterEffectsSubmitDeadline(
     families = ["render.farm"]  # cannot be "render' as that is integrated
     use_published = True
     targets = ["local"]
+    settings_category = "deadline"
 
     priority = 50
     chunk_size = 1000000

--- a/client/ayon_deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/client/ayon_deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -14,6 +14,7 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
     order = pyblish.api.ValidatorOrder
     families = ["render"]
     targets = ["deadline"]
+    settings_category = "deadline"
 
     # check if actual frame range on render job wasn't different
     # case when artists wants to render only subset of frames


### PR DESCRIPTION
### Changes

Fix missing `settings_category = "deadline"` attribute for plug-ins that do appear in settings

### Testing notes:

1. Settings should work for After Effects submissions plug-in `AfterEffectsSubmitDeadline`
2. Settings should work for `ValidateExpectedFiles` for renders