### PR TITLE
Pass staging as settings variant

### DIFF
--- a/client/ayon_deadline/plugins/publish/submit_houdini_cache_deadline.py
+++ b/client/ayon_deadline/plugins/publish/submit_houdini_cache_deadline.py
@@ -101,12 +101,15 @@ class HoudiniCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
             "FTRACK_API_USER",
             "FTRACK_SERVER",
             "OPENPYPE_SG_USER",
+            "AYON_BUNDLE_NAME",
+            "AYON_DEFAULT_SETTINGS_VARIANT",
             "AYON_PROJECT_NAME",
             "AYON_FOLDER_PATH",
             "AYON_TASK_NAME",
             "AYON_WORKDIR",
             "AYON_APP_NAME",
             "AYON_LOG_NO_COLORS",
+            "AYON_IN_TESTS"
         ]
 
         environment = {

--- a/client/ayon_deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -248,12 +248,15 @@ class HoudiniSubmitDeadline(
             "FTRACK_API_USER",
             "FTRACK_SERVER",
             "OPENPYPE_SG_USER",
+            "AYON_BUNDLE_NAME",
+            "AYON_DEFAULT_SETTINGS_VARIANT",
             "AYON_PROJECT_NAME",
             "AYON_FOLDER_PATH",
             "AYON_TASK_NAME",
             "AYON_WORKDIR",
             "AYON_APP_NAME",
             "AYON_LOG_NO_COLORS",
+            "AYON_IN_TESTS"
         ]
 
         environment = {

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -13,7 +13,7 @@ from Deadline.Scripting import (
     FileUtils,
     DirectoryUtils,
 )
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"
@@ -496,6 +496,12 @@ def inject_ayon_environment(deadlinePlugin):
             "extractenvironments",
             export_url
         ]
+
+        # staging requires passing argument
+        settings_variant = job.GetJobEnvironmentKeyValue("AYON_DEFAULT_SETTINGS_VARIANT")  # noqa
+        if settings_variant == "staging":
+            args.append("--use-staging")
+
         # Backwards compatibility for older versions
         legacy_args = [
             "--headless",

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -498,6 +498,7 @@ def inject_ayon_environment(deadlinePlugin):
         ]
 
         # staging requires passing argument
+        # TODO could be switched to env var after https://github.com/ynput/ayon-launcher/issues/123
         settings_variant = job.GetJobEnvironmentKeyValue("AYON_DEFAULT_SETTINGS_VARIANT")  # noqa
         if settings_variant == "staging":
             args.append("--use-staging")


### PR DESCRIPTION
If -use-staging is used in published job, this will propagate it to the AYON process for environment extraction. 
Must use command line argument, environment variable won't get picked up.

This requires redeploy of `GlobalJobPreLoad.py`!