### PR TITLE
Do not fail job on error in GlobalJobPreLoad

### DIFF
--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -13,7 +13,7 @@ from Deadline.Scripting import (
     FileUtils,
     DirectoryUtils,
 )
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -407,7 +407,6 @@ def inject_openpype_environment(deadlinePlugin):
         import traceback
         print(traceback.format_exc())
         print("!!! Injection failed.")
-        RepositoryUtils.FailJob(job)
         raise
 
 
@@ -581,7 +580,6 @@ def inject_ayon_environment(deadlinePlugin):
         import traceback
         print(traceback.format_exc())
         print("!!! Injection failed.")
-        RepositoryUtils.FailJob(job)
         raise
 
 


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Do not force the full job to fail - it may be just this machine has a server connection timeout.
This allows a single machine to fail - yet others to continue in the queue.
This also allows a single machine to try again - since it'll use Deadline's default "mark bad after X errors" setting to decide when a worker is 'bad'.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Fix #14

## Testing notes:

1. Submit job to Deadline
2. Turn off your AYON server (or do whatever to make the GlobalJobPreLoad fail)
3. It should not instantly mark the full job and all its task "failed"