### PR TITLE
adding support for {representation} anatomy key

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -569,6 +569,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "name": product_name,
             "type": product_type,
         }
+        template_data["representation"] = ""
 
         render_dir_template = anatomy.get_template_item(
             "publish", template_name, "directory"


### PR DESCRIPTION
## Changelog Description
adding empty string to dictionary TEMLATE DATA [representation] because this key solves later in integration step so for submossion time its not here and need to presist as var but be empty


## Testing notes:
to recreate a bug:
1. add {representation} key to anatomy tempate
2. try to publish and see it fails
3. try this PR and ses that it passes and all representations collected in separate folders
