### PR TITLE
Collect server url: Access server info correctly

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
@@ -40,7 +40,8 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
         if dl_server_info:
             deadline_url = dl_server_info["value"]
         else:
-            default_dl_server_info = deadline_addon.deadline_servers_info[0]
+            key = next(k for k in deadline_addon.deadline_servers_info.keys())
+            default_dl_server_info = deadline_addon.deadline_servers_info[key]
             deadline_url = default_dl_server_info["value"]
 
         context.data["deadline"] = {}


### PR DESCRIPTION
## Changelog Description
[deadline_addon.deadline_servers_info](https://github.com/ynput/ayon-deadline/blob/bb0d1929836a172d712223f2d781278055a017e9/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py#L43-L44) seems to be a dictionary so accessing items through indexes as if it was a list raises an error.


## Testing notes:

1. start with this step
2. follow this step
