### PR TITLE
Make sure multicamera render from 3dsmax uses correct camera in farm submission

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -309,7 +309,8 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             scene_filename = os.path.basename(scene_filepath)
             scene_directory = os.path.dirname(scene_filepath)
             current_filename, ext = os.path.splitext(scene_filename)
-            camera_scene_name = f"{current_filename}_{camera}{ext}"
+            camera_name = camera.replace(":", "_")
+            camera_scene_name = f"{current_filename}_{camera_name}{ext}"
             camera_scene_filepath = os.path.join(
                 scene_directory, f"_{current_filename}", camera_scene_name)
             plugin_data["SceneFile"] = camera_scene_filepath


### PR DESCRIPTION
## Changelog Description
Relevant to https://github.com/ynput/ayon-3dsmax/pull/13
This PR is to fix the bug of using same camera across the scenes in 3dsmax when multicamera option is enabled, while resolving the special characters are not allowed as being the render output and scene file names
Resolve https://github.com/ynput/ayon-3dsmax/issues/12


## Additional info
Test along with https://github.com/ynput/ayon-3dsmax/pull/13


## Testing notes:

1. Build and install deadline addon with this branch
2. Publish render with multicamera option enabled in 3dsmax
