### PR TITLE
Baking chunk size for sequences

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -350,9 +350,16 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
 
         # TODO: rewrite for baking with sequences
         if baking_submission:
+            baking_chunk = 99999999
+            if '#' in render_path:
+                # baking with sequences
+                baking_chunk = instance.data["attributeValues"].get(
+                    "chunk", 99999999)
+                self.log.debug(
+                    f"Baking to image sequence, chunk size: {baking_chunk}")
             payload["JobInfo"].update({
                 "JobType": "Normal",
-                "ChunkSize": 99999999
+                "ChunkSize": baking_chunk
             })
 
         if response_data.get("_id"):


### PR DESCRIPTION
## Changelog Description
Supporting deadline rendering of Nuke baking jobs (Extract Review Intermediate) with multi chunks.
The Chunk size is copied from the ```ayon+settings://deadline/publish/NukeSubmitDeadline/chunk_size```

## Additional info
Might close https://github.com/ynput/ayon-nuke/issues/3

## Testing notes:
1. Set Extract Review Intermediate to jpg
2. Make sure you do not have Nuke Slate present (see bug)
3. Publish Nuke render on Deadline
4. Check Number of tasks for baking job in Deadline Monitor, it should be > 1
