### PR TITLE
Review: Don't pass ftrack family to jobs

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -156,7 +156,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
     }
 
     # list of family names to transfer to new family if present
-    families_transfer = ["render3d", "render2d", "ftrack", "slate"]
+    families_transfer = ["render3d", "render2d", "slate"]
     plugin_pype_version = "3.0"
 
     # poor man exclusion

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -570,7 +570,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
         "deadline_group": "",
         "deadline_priority": 50,
         "skip_integration_repre_list": [],
-        "families_transfer": ["render3d", "render2d", "ftrack", "slate"],
+        "families_transfer": ["render3d", "render2d", "slate"],
         "aov_filter": [
             {
                 "name": "maya",


### PR DESCRIPTION
## Changelog Description
Do not pass ftrack family to publish instance.

## Additional info
It is job of ftrack addon to care about it. Collect ftrack family should be running on farm too, or I might miss something?

## Testing notes:
1. Create package, upload to server, add to bundle (with ftrack addon).
2. Send job to deadline that should create review.
3. The review should go to ftrack.
