### PR TITLE
implement callbacks to show attributes if `farm` is enabled

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_pools.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_pools.py
@@ -69,7 +69,15 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
             instance.data["secondaryPool"] = None
 
     @classmethod
-    def get_attribute_defs(cls):
+    def get_attr_defs_for_instance(cls, create_context, instance):
+        # Filtering of instance, if needed, can be customized
+        if not cls.instance_matches_plugin_families(instance):
+            return []
+
+        # Attributes logic
+        creator_attributes = instance["creator_attributes"]
+
+        visible = creator_attributes.get("farm", False)
         # TODO: Preferably this would be an enum for the user
         #       but the Deadline server URL can be dynamic and
         #       can be set per render instance. Since get_attribute_defs
@@ -83,10 +91,42 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
                     label="Primary Pool",
                     default=cls.primary_pool,
                     tooltip="Deadline primary pool, "
-                            "applicable for farm rendering"),
+                            "applicable for farm rendering",
+                    visible=visible),
             TextDef("secondaryPool",
                     label="Secondary Pool",
                     default=cls.secondary_pool,
                     tooltip="Deadline secondary pool, "
-                            "applicable for farm rendering")
+                            "applicable for farm rendering",
+                    visible=visible)
         ]
+
+    @classmethod
+    def register_create_context_callbacks(cls, create_context):
+        create_context.add_value_changed_callback(cls.on_values_changed)
+
+    @classmethod
+    def on_values_changed(cls, event):
+        """Update instance attribute definitions on attribute changes."""
+
+        # Update attributes if any of the following plug-in attributes
+        # change:
+        keys = ["farm"]
+
+        for instance_change in event["changes"]:
+            instance = instance_change["instance"]
+            if not cls.instance_matches_plugin_families(instance):
+                continue
+            value_changes = instance_change["changes"]
+            plugin_attribute_changes = (
+                value_changes.get("creator_attributes", {})
+                .get(cls.__name__, {}))
+
+            if not any(key in plugin_attribute_changes for key in keys):
+                continue
+
+            # Update the attribute definitions
+            new_attrs = cls.get_attr_defs_for_instance(
+                event["create_context"], instance
+            )
+            instance.set_publish_plugin_attr_defs(cls.__name__, new_attrs)

--- a/client/ayon_deadline/plugins/publish/global/collect_pools.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_pools.py
@@ -69,15 +69,7 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
             instance.data["secondaryPool"] = None
 
     @classmethod
-    def get_attr_defs_for_instance(cls, create_context, instance):
-        # Filtering of instance, if needed, can be customized
-        if not cls.instance_matches_plugin_families(instance):
-            return []
-
-        # Attributes logic
-        creator_attributes = instance["creator_attributes"]
-
-        visible = creator_attributes.get("farm", False)
+    def get_attribute_defs(cls):
         # TODO: Preferably this would be an enum for the user
         #       but the Deadline server URL can be dynamic and
         #       can be set per render instance. Since get_attribute_defs
@@ -91,42 +83,10 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
                     label="Primary Pool",
                     default=cls.primary_pool,
                     tooltip="Deadline primary pool, "
-                            "applicable for farm rendering",
-                    visible=visible),
+                            "applicable for farm rendering"),
             TextDef("secondaryPool",
                     label="Secondary Pool",
                     default=cls.secondary_pool,
                     tooltip="Deadline secondary pool, "
-                            "applicable for farm rendering",
-                    visible=visible)
+                            "applicable for farm rendering")
         ]
-
-    @classmethod
-    def register_create_context_callbacks(cls, create_context):
-        create_context.add_value_changed_callback(cls.on_values_changed)
-
-    @classmethod
-    def on_values_changed(cls, event):
-        """Update instance attribute definitions on attribute changes."""
-
-        # Update attributes if any of the following plug-in attributes
-        # change:
-        keys = ["farm"]
-
-        for instance_change in event["changes"]:
-            instance = instance_change["instance"]
-            if not cls.instance_matches_plugin_families(instance):
-                continue
-            value_changes = instance_change["changes"]
-            plugin_attribute_changes = (
-                value_changes.get("creator_attributes", {})
-                .get(cls.__name__, {}))
-
-            if not any(key in plugin_attribute_changes for key in keys):
-                continue
-
-            # Update the attribute definitions
-            new_attrs = cls.get_attr_defs_for_instance(
-                event["create_context"], instance
-            )
-            instance.set_publish_plugin_attr_defs(cls.__name__, new_attrs)


### PR DESCRIPTION
## Changelog Description
This PR implement callbacks to some plugins show attributes if `farm` is enabled.
I only tested it in Houdini. 

> [!Note]
> This PR is mainly made for sharing code and show a use case  for https://github.com/ynput/ayon-core/pull/994
> It should be used along https://github.com/ynput/ayon-deadline/pull/49 and https://github.com/ynput/ayon-houdini/pull/149
> Here's what to expect when using the three PRs togther
> ![Animation_17](https://github.com/user-attachments/assets/ca34383e-1a40-4926-8487-d8a584be2512)

## Testing notes:
1. Launch Houdini via AYON
2. Create a cache instance (vdb, model, pointcache, ass, rsproxy)
3. Switch farm toggle in the publisher UI, click save,  click refresh and watch the attributes appear and disappear.
