### PR TITLE
Chore: Don't override already set env variables

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
@@ -36,15 +36,15 @@ class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
     ]
 
     def process(self, context):
-        env = {}
+        env = context.data.setdefault(JOB_ENV_DATA_KEY, {})
         for key in self.ENV_KEYS:
+            # Skip already set keys
+            if key in env:
+                continue
             value = os.getenv(key)
             if value:
                 self.log.debug(f"Setting job env: {key}: {value}")
                 env[key] = value
-
-        # Transfer some environment variables from current context
-        context.data.setdefault(JOB_ENV_DATA_KEY, {}).update(env)
 
 
 class CollectAYONServerToFarmJob(CollectDeadlineJobEnvVars):


### PR DESCRIPTION
## Changelog Description
Collect farm env variables does not override already set environment variables.

## Testing notes:
1. Environment variables should be passed to jobs correctly.
