### PR TITLE
Fix use existing frames workflow in Nuke

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -94,7 +94,8 @@ class NukeSubmitDeadline(
             for baking_script in instance.data["bakingNukeScripts"]:
                 self.job_info.JobType = "Normal"
 
-                response_data = instance.data["deadlineSubmissionJob"]
+                response_data = instance.data.get("deadlineSubmissionJob", {})
+                # frames_farm instance doesn't have render submission
                 if response_data.get("_id"):
                     self.job_info.BatchName = response_data["Props"]["Batch"]
                     self.job_info.JobDependency0 = response_data["_id"]


### PR DESCRIPTION
## Changelog Description
Fixing `Use existing frames` Nuke workflow where there is no first render submission

## Additional review information
Solves 
```
submit_nuke_deadline.py", line 101, in process
    response_data = instance.data["deadlineSubmissionJob"]
KeyError: 'deadlineSubmissionJob'
```

## Testing notes:
1. set  `Use existing frames`  in Nuke
2. publish, shouldnt fail
