### PR TITLE
Force disable Houdini USD render to not use the published file for rendering

### DIFF
--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -346,7 +346,8 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
     label = "Submit Render to Deadline (USD)"
     families = ["usdrender"]
 
-    # Do not use published workfile paths for USD Render ROP because the
-    # Export Job doesn't seem to occur using the published path either, so
-    # output paths then do not match the actual rendered paths
-    use_published = False
+    def from_published_scene(self, replace_in_path=True):
+        # Do not use published workfile paths for USD Render ROP because the
+        # Export Job doesn't seem to occur using the published path either, so
+        # output paths then do not match the actual rendered paths
+        return


### PR DESCRIPTION
## Changelog Description

Force disable Houdini USD render to not use the published file for rendering

## Additional review information

Fixes #82

## Testing notes:

1. Submit Houdini usd render
2. Publish should succeed regardless of "Use Published" setting in default profiles
