### PR TITLE
Fusion: Fix submission of multiple fusion render instances

### DIFF
--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -87,10 +87,10 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
         # Store the response for dependent job submission plug-ins for all
         # the instances
+        transfer_keys = ["deadlineSubmissionJob", "deadline"]
         for saver_instance in saver_instances:
-            saver_instance.data["deadlineSubmissionJob"] = (
-                instance.data["deadlineSubmissionJob"]
-            )
+            for key in transfer_keys:
+                saver_instance.data[key] = instance.data[key]
 
     def get_job_info(self, job_info=None, **kwargs):
         instance = self._instance


### PR DESCRIPTION
## Changelog Description

Fix submission of multiple fusion render instances in one go by also storing `instance.data["deadline"]` correctly to each instance

## Additional review information

Fixes error:
```python
Traceback (most recent call last):
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\dependency_packages\ayon_2407291312_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\deadline_0.5.1+cb.1\ayon_deadline\plugins\publish\global\submit_publish_job.py", line 418, in process
    representations = prepare_representations(
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\core_1.0.10+cb.1\ayon_core\pipeline\farm\pyblish_functions.py", line 340, in prepare_representations
    frames_to_render = _get_real_frames_to_render(frames_to_render)
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\core_1.0.10+cb.1\ayon_core\pipeline\farm\pyblish_functions.py", line 493, in _get_real_frames_to_render
    frames_to_render.append(int(frame))
ValueError: invalid literal for int() with base 10: ''
```

## Testing notes:
1. Create multiple render saver instances.
2. Publish both at the same time via the farm.
