### PR TITLE
Harmony: Render to workdir instead of publish dir

### DIFF
--- a/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
+++ b/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
@@ -347,6 +347,9 @@ class HarmonySubmitDeadline(
 
         # for submit_publish job to create .json file in
         self._instance.data["outputDir"] = render_path
+        # to let DL Explore Output
+        # TODO update this when #79 is fixed
+        self.job_info.OutputDirectory[0] = render_path.as_posix()
         new_expected_files = []
         render_path_str = str(render_path.as_posix())
         for file in self._instance.data["expectedFiles"]:

--- a/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
+++ b/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
@@ -12,8 +12,6 @@ import pyblish.api
 
 from ayon_deadline import abstract_submit_deadline
 
-import ayon_harmony.api as harmony
-
 
 class _ZipFile(ZipFile):
     """Extended check for windows invalid characters."""
@@ -254,7 +252,7 @@ class HarmonySubmitDeadline(
     def _unzip_scene_file(self, published_scene: Path) -> Path:
         """Unzip scene zip file to its directory.
 
-        Unzip scene file (if it is zip file) to workfidir if available,
+        Unzip scene file (if it is zip file) to work are if dir if available,
         if not to its current directory and
         return path to xstage file there. Xstage file is determined by its
         name.
@@ -273,29 +271,18 @@ class HarmonySubmitDeadline(
             self.log.error(published_scene)
             raise AssertionError("invalid scene format")
 
-        try:
-            workdir = harmony.get_workdir()
-        except AttributeError:
-            # TODO remove when dependency on DL will be added
-            # after DL release
-            self.log.info(
-                "'get_workdir' doesn't exist in Harmony addon. "
-                "You are using older version, falling back to "
-                "render in 'publish' workfile folder."
-            )
-
-        if workdir:
-            workdir = Path(workdir)
-            renders_path = os.path.join(
-                workdir.parent, "renders", "harmony")
+        # TODO eventually replace with registered_host().work_root or similar
+        workdir = os.environ.get("AYON_WORKDIR")
+        if workdir and os.path.exists(workdir):
+            renders_path = os.path.join(workdir, "renders", "harmony")
             os.makedirs(renders_path, exist_ok=True)
 
             self.log.info(f"Copying '{published_scene}' -> '{renders_path}'")
-            shutil.copy(
-                published_scene.as_posix(), renders_path)
+            shutil.copy(published_scene.as_posix(), renders_path)
             published_scene = Path(
                 os.path.join(renders_path), published_scene.name)
-            self._instance.context.data["cleanupFullPaths"].append(published_scene)
+            (self._instance.context.data["cleanupFullPaths"].
+             append(published_scene))
 
         xstage_path = (
             published_scene.parent

--- a/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
+++ b/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
@@ -223,6 +223,10 @@ class HarmonySubmitDeadline(
     Renders are submitted to a Deadline Web Service as
     supplied via the environment variable ``DEADLINE_REST_URL``.
 
+    Harmony workfile is `.zip` file that needs to be unzipped for Deadline
+    first (DL expects unzipped folder). In case of use of published workfile,
+    `.zip` file is copied to `work/../renders` and unzipped there.
+
     Note:
         If Deadline configuration is not detected, this plugin will
         be disabled.
@@ -252,7 +256,7 @@ class HarmonySubmitDeadline(
     def _unzip_scene_file(self, published_scene: Path) -> Path:
         """Unzip scene zip file to its directory.
 
-        Unzip scene file (if it is zip file) to work are if dir if available,
+        Unzip scene file (if it is zip file) to work area if dir if available,
         if not to its current directory and
         return path to xstage file there. Xstage file is determined by its
         name.

--- a/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
+++ b/client/ayon_deadline/plugins/publish/harmony/submit_harmony_deadline.py
@@ -279,7 +279,7 @@ class HarmonySubmitDeadline(
             # TODO remove when dependency on DL will be added
             # after DL release
             self.log.info(
-                f"'get_workdir' doesn't exist in Harmony addon. "
+                "'get_workdir' doesn't exist in Harmony addon. "
                 "You are using older version, falling back to "
                 "render in 'publish' workfile folder."
             )


### PR DESCRIPTION
## Changelog Description
Published workfile needs to be used for Deadline rendering as real incremented version of workfile is not created only after DL submission.
This PR moves intermediate rendered frames to `work` area in similar fashion as other DCCs.

## Additional review information
~~This PR requires (https://github.com/ynput/ayon-harmony/pull/20)
For now it should be handling presence of that Harmony addon version safely, it will be cleaned up before full release.~~
Replaced by AYON_WORKDIR env var.

## Testing notes:
1. publish to DL
2. check that workfile is unzipped in `work/TASK_NAME/renders/harmony/VERSIONED_FOLDER
