### PR TITLE
Do not set environment env variables from ayon-core

### DIFF
--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -2,7 +2,6 @@ import json
 from dataclasses import dataclass, field, asdict
 from functools import partial
 from typing import Optional, List, Tuple, Any, Dict
-from enum import Enum
 
 import requests
 

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -47,10 +47,12 @@ def get_instance_job_envs(instance) -> "dict[str, str]":
 
     Any instance `job_env` vars will override the context `job_env` vars.
     """
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
     env = {}
     for job_env in [
-        instance.context.data.get(JOB_ENV_DATA_KEY, {}),
-        instance.data.get(JOB_ENV_DATA_KEY, {})
+        instance.context.data.get(FARM_JOB_ENV_DATA_KEY, {}),
+        instance.data.get(FARM_JOB_ENV_DATA_KEY, {})
     ]:
         if job_env:
             env.update(job_env)

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
@@ -2,7 +2,7 @@ import os
 
 import pyblish.api
 
-from ayon_deadline.lib import JOB_ENV_DATA_KEY
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
 
 
 class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
@@ -36,7 +36,7 @@ class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
     ]
 
     def process(self, context):
-        env = context.data.setdefault(JOB_ENV_DATA_KEY, {})
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
         for key in self.ENV_KEYS:
             # Skip already set keys
             if key in env:

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
@@ -12,27 +12,19 @@ class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
     targets = ["local"]
 
     ENV_KEYS = [
-        # AYON
-        "AYON_BUNDLE_NAME",
-        "AYON_DEFAULT_SETTINGS_VARIANT",
-        "AYON_PROJECT_NAME",
-        "AYON_FOLDER_PATH",
-        "AYON_TASK_NAME",
+        # applications addon
         "AYON_APP_NAME",
-        "AYON_WORKDIR",
-        "AYON_APP_NAME",
-        "AYON_LOG_NO_COLORS",
-        "AYON_IN_TESTS",
-        "IS_TEST",  # backwards compatibility
 
-        # Ftrack
+        # ftrack addon
         "FTRACK_API_KEY",
         "FTRACK_API_USER",
         "FTRACK_SERVER",
-        "PYBLISHPLUGINPATH",
 
-        # Shotgrid
+        # Shotgrid / Flow addon
         "OPENPYPE_SG_USER",
+
+        # Not sure how this is usefull for farm, scared to remove
+        "PYBLISHPLUGINPATH",
     ]
 
     def process(self, context):

--- a/client/ayon_deadline/plugins/publish/global/collect_usd_pinning_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_usd_pinning_env_vars.py
@@ -1,6 +1,6 @@
 import pyblish.api
 
-from ayon_deadline.lib import JOB_ENV_DATA_KEY
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
 
 try:
     from ayon_usd import get_usd_pinning_envs
@@ -41,7 +41,7 @@ class CollectUSDPinningEnvVars(pyblish.api.InstancePlugin):
             self.log.debug("Should not be processed on farm, skipping.")
             return
 
-        job_env = instance.data.setdefault(JOB_ENV_DATA_KEY, {})
+        job_env = instance.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
         usd_pinning_envs: dict = get_usd_pinning_envs(instance)
 
         # Log the job envs that are set

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -18,6 +18,7 @@ from ayon_core.pipeline.farm.pyblish_functions import (
     prepare_cache_representations,
     create_metadata_path
 )
+from ayon_deadline.lib import get_instance_job_envs
 from ayon_deadline.abstract_submit_deadline import requests_post
 
 
@@ -60,17 +61,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
     hosts = ["houdini"]
 
     families = ["publish.hou"]
-
-    environ_keys = [
-        "FTRACK_API_USER",
-        "FTRACK_API_KEY",
-        "FTRACK_SERVER",
-        "AYON_APP_NAME",
-        "AYON_USERNAME",
-        "AYON_SG_USERNAME",
-        "KITSU_LOGIN",
-        "KITSU_PWD"
-    ]
 
     # custom deadline attributes
     deadline_department = ""
@@ -118,26 +108,12 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         metadata_path, rootless_metadata_path = \
             create_metadata_path(instance, anatomy)
 
-        environment = {
-            "AYON_PROJECT_NAME": instance.context.data["projectName"],
-            "AYON_FOLDER_PATH": instance.context.data["folderPath"],
-            "AYON_TASK_NAME": instance.context.data["task"],
-            "AYON_USERNAME": instance.context.data["user"],
-            "AYON_LOG_NO_COLORS": "1",
-            "AYON_IN_TESTS": str(int(is_in_tests())),
+        environment = get_instance_job_envs(instance)
+        environment.update({
             "AYON_PUBLISH_JOB": "1",
             "AYON_RENDER_JOB": "0",
             "AYON_REMOTE_PUBLISH": "0",
-            "AYON_BUNDLE_NAME": os.environ["AYON_BUNDLE_NAME"],
-            "AYON_DEFAULT_SETTINGS_VARIANT": (
-                os.environ["AYON_DEFAULT_SETTINGS_VARIANT"]
-            ),
-        }
-
-        # add environments from self.environ_keys
-        for env_key in self.environ_keys:
-            if os.getenv(env_key):
-                environment[env_key] = os.environ[env_key]
+        })
 
         priority = self.deadline_priority or instance.data.get("priority", 50)
 


### PR DESCRIPTION
## Changelog Description
Use constant `FARM_JOB_ENV_DATA_KEY` from ayon-core instead of `JOB_ENV_DATA_KEY`. And do not fill environment variables that are filled by ayon-core already.

## Additional review information
One step closer to avoid setting up environment variables that have nothing to do with deadline. Validate that all removed environment variables are already set by ayon-core.

Marked code in `lib.py` that is pipeline related and probably should not be there as the file is imported by `addon.py`.

## Testing notes:
1. Submit jobs before this PR and with this PR and compare environment variables in the jobs (using deadline monitor).

