### PR TITLE
Chore: Add submit api functions

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -12,8 +12,8 @@ from datetime import datetime
 from copy import deepcopy
 
 import requests
-
 import pyblish.api
+
 from ayon_core.pipeline.publish import (
     AbstractMetaInstancePlugin,
     KnownPublishError,
@@ -24,7 +24,7 @@ from ayon_core.pipeline.publish.lib import (
 )
 from ayon_core.pipeline.farm.tools import iter_expected_files
 from ayon_core.lib import is_in_tests
-from ayon_deadline.lib import AYONDeadlineJobInfo
+from ayon_deadline.lib import PublishDeadlineJobInfo
 
 JSONDecodeError = getattr(json.decoder, "JSONDecodeError", ValueError)
 
@@ -104,7 +104,9 @@ class AbstractSubmitDeadline(
         self.job_info = self.get_job_info(job_info=deepcopy(job_info))
 
         self._set_scene_path(
-            context.data["currentFile"], job_info.UsePublished)
+            context.data["currentFile"],
+            job_info.use_published
+        )
         self.plugin_info = self.get_plugin_info()
 
         self.aux_files = self.get_aux_files()
@@ -198,7 +200,7 @@ class AbstractSubmitDeadline(
             job_info.OutputFilename += os.path.basename(filepath)
 
         # Adding file dependencies.
-        if not is_in_tests() and job_info.UseAssetDependencies:
+        if not is_in_tests() and job_info.use_asset_dependencies:
             dependencies = instance.context.data.get("fileDependencies", [])
             for dependency in dependencies:
                 job_info.AssetDependency += dependency
@@ -222,14 +224,14 @@ class AbstractSubmitDeadline(
         This is host/plugin specific implementation of how to fill data in.
 
         Args:
-            job_info (AYONDeadlineJobInfo): dataclass object with collected
+            job_info (PublishDeadlineJobInfo): dataclass object with collected
                 values from Settings and Publisher UI
 
         See:
-            :class:`AYONDeadlineJobInfo`
+            :class:`PublishDeadlineJobInfo`
 
         Returns:
-            :class:`DeadlineJobInfo`: Filled Deadline JobInfo.
+            :class:`PublishDeadlineJobInfo`: Filled Deadline JobInfo.
 
         """
         pass
@@ -241,7 +243,7 @@ class AbstractSubmitDeadline(
         This is host/plugin specific implementation of how to fill data in.
 
         See:
-            :class:`DeadlineJobInfo`
+            :class:`PublishDeadlineJobInfo`
 
         Returns:
             dict: Filled Deadline JobInfo.
@@ -290,8 +292,8 @@ class AbstractSubmitDeadline(
         """Assemble payload data from its various parts.
 
         Args:
-            job_info (DeadlineJobInfo): Deadline JobInfo. You can use
-                :class:`DeadlineJobInfo` for it.
+            job_info (PublishDeadlineJobInfo): Deadline JobInfo. You can use
+                :class:`PublishDeadlineJobInfo` for it.
             plugin_info (dict): Deadline PluginInfo. Plugin specific options.
             aux_files (list, optional): List of auxiliary file to submit with
                 the job.

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -10,6 +10,7 @@ import getpass
 import os
 from datetime import datetime
 from copy import deepcopy
+from typing import Optional
 
 import requests
 import pyblish.api
@@ -173,7 +174,7 @@ class AbstractSubmitDeadline(
 
     def get_generic_job_info(self, instance: pyblish.api.Instance):
         context: pyblish.api.Context = instance.context
-        job_info: AYONDeadlineJobInfo = instance.data["deadline"]["job_info"]
+        job_info: PublishDeadlineJobInfo = instance.data["deadline"]["job_info"]
 
         # Always use the original work file name for the Job name even when
         # rendering is done from the published Work File. The original work
@@ -218,7 +219,9 @@ class AbstractSubmitDeadline(
             self.plugin_info[key] = value
 
     @abstractmethod
-    def get_job_info(self, job_info=None, **kwargs):
+    def get_job_info(
+        self, job_info: Optional[PublishDeadlineJobInfo] = None, **kwargs
+    ):
         """Return filled Deadline JobInfo.
 
         This is host/plugin specific implementation of how to fill data in.

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -97,7 +97,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         plugin_info: Dict[str, Any],
         job_info: Dict[str, Any],
         aux_files: Optional[List[str]] = None,
-    ) -> str:
+    ) -> Dict[str, Any]:
         """Submit job to Deadline.
 
         Args:
@@ -125,7 +125,9 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         )
         if not response.ok:
             raise ValueError("Failed to create job")
-        return response.json()["_id"]
+
+        payload["job_id"] = response.json()["_id"]
+        return payload
 
     def submit_ayon_plugin_job(
         self,
@@ -149,7 +151,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         custom_job_info: Optional[Dict[str, Any]] = None,
         aux_files: Optional[List[str]] = None,
         frames: Optional[str] = None,
-    ) -> str:
+    ) -> Dict[str, Any]:
         if chunk_size is None:
             chunk_size = 1
 
@@ -229,7 +231,9 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             "Arguments": command,
             "SingleFrameOnly": "True",
         }
-        return self.submit_job(server_name, plugin_info, job_info, aux_files)
+        return self.submit_job(
+            server_name, plugin_info, job_info, aux_files
+        )
 
     def _get_deadline_con_info(
         self, server_name: str

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -144,6 +144,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         pool: Optional[str] = None,
         secondary_pool: Optional[str] = None,
         output_directories: Optional[List[str]] = None,
+        output_filenames: Optional[List[str]] = None,
         username: Optional[str] = None,
         comment: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
@@ -179,6 +180,9 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         if output_directories is None:
             output_directories = []
 
+        if output_filenames is None:
+            output_filenames = []
+
         if env is None:
             env = {}
 
@@ -211,8 +215,11 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         for idx, job_id in enumerate(dependency_job_ids):
             job_info[f"JobDependency{idx}"] = job_id
 
-        for idx, job_id in enumerate(output_directories):
-            job_info[f"OutputDirectory{idx}"] = job_id
+        for idx, directory in enumerate(output_directories):
+            job_info[f"OutputDirectory{idx}"] = directory
+
+        for idx, filename in enumerate(output_filenames):
+            job_info[f"OutputFilename{idx}"] = filename
 
         for idx, (key, value) in enumerate(env.items()):
             info_key = f"EnvironmentKeyValue{idx}"

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -154,9 +154,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             auth=auth,
             verify=verify
         )
-        if not response.ok:
-            raise ValueError("Failed to create job")
-
+        response.raise_for_status()
         payload["response"] = response.json()
         return payload
 

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -141,6 +141,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         group: Optional[str] = None,
         pool: Optional[str] = None,
         secondary_pool: Optional[str] = None,
+        output_directories: Optional[List[str]] = None,
         username: Optional[str] = None,
         comment: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
@@ -172,6 +173,9 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         if dependency_job_ids is None:
             dependency_job_ids = []
 
+        if output_directories is None:
+            output_directories = []
+
         if env is None:
             env = {}
 
@@ -202,6 +206,9 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
 
         for idx, job_id in enumerate(dependency_job_ids):
             job_info[f"JobDependency{idx}"] = job_id
+
+        for idx, job_id in enumerate(output_directories):
+            job_info[f"OutputDirectory{idx}"] = job_id
 
         for idx, (key, value) in enumerate(env.items()):
             info_key = f"EnvironmentKeyValue{idx}"

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -271,7 +271,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         require_authentication = server_info["require_authentication"]
         if require_authentication:
             if local_settings is None:
-                local_setting = self._get_local_settings()
+                local_settings = self._get_local_settings()
 
             for server_info in local_settings["local_settings"]:
                 if server_name != server_info["server_name"]:

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -90,6 +90,31 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
 
         return server_info
 
+    def get_job_info(
+        self, server_name: str, job_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get job info from Deadline.
+
+        Args:
+            server_name (str): Deadline Server name from project Settings.
+            job_id (str): Deadline job id.
+
+        Returns:
+            Optional[Dict[str, Any]]: Job info from Deadline.
+
+        """
+        server_url, auth, verify = self._get_deadline_con_info(server_name)
+        response = requests.get(
+            f"{server_url}/api/jobs?JobID={job_id}",
+            auth=auth,
+            verify=verify
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data:
+            return data.pop(0)
+        return None
+
     def submit_job(
         self,
         server_name: str,

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -78,7 +78,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         """
         server_info = self._server_info_by_name.get(server_name)
         if server_info is None:
-            server_url, auth, _ = self._get_deadline_con_info(server_name)
+            server_url, auth, _ = self.get_deadline_server_info(server_name)
             pools = get_deadline_pools(server_url, auth)
             groups = get_deadline_groups(server_url, auth)
             limit_groups = get_deadline_limit_groups(server_url, auth)
@@ -106,7 +106,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             Optional[Dict[str, Any]]: Job info from Deadline.
 
         """
-        server_url, auth, verify = self._get_deadline_con_info(server_name)
+        server_url, auth, verify = self.get_deadline_server_info(server_name)
         response = requests.get(
             f"{server_url}/api/jobs?JobID={job_id}",
             auth=auth,
@@ -146,7 +146,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             "PluginInfo": plugin_info,
             "AuxFiles": aux_files or [],
         }
-        server_url, auth, verify = self._get_deadline_con_info(server_name)
+        server_url, auth, verify = self.get_deadline_server_info(server_name)
         response = requests.post(
             f"{server_url}/api/jobs",
             json=payload,
@@ -195,7 +195,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             server_name, plugin_info, job_info, aux_files
         )
 
-    def _get_deadline_con_info(
+    def get_deadline_server_info(
         self, server_name: str
     ) -> Tuple[str, Optional[Tuple[str, str]], bool]:
         dl_server_info = self.deadline_servers_info[server_name]

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -148,6 +148,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         dependency_job_ids: Optional[List[str]] = None,
         custom_job_info: Optional[Dict[str, Any]] = None,
         aux_files: Optional[List[str]] = None,
+        frames: Optional[str] = None,
     ) -> str:
         if chunk_size is None:
             chunk_size = 1
@@ -200,6 +201,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             ("Group", group),
             ("Pool", pool),
             ("SecondaryPool", secondary_pool),
+            ("Frames", frames),
         ):
             if value is not None:
                 job_info[key] = value

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -130,11 +130,12 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         Args:
             server_name (str): Deadline Server name from project Settings.
             plugin_info (dict): Plugin info data.
-            job_info (dict): Job info data.
+            job_info (Union[DeadlineJobInfo, Dict[str, Any]]): Job info data.
             aux_files (Optional[List[str]]): List of auxiliary files.
 
         Returns:
-            Dict[str, Any]: Job payload, with 'job_id' key.
+            Dict[str, Any]: Job payload, with 'response' key containing
+                response data.
 
         """
         if isinstance(job_info, DeadlineJobInfo):

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -249,6 +249,18 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             not dl_server_info["not_verify_ssl"],
         )
 
+    def _get_local_settings(self) -> Dict[str, Any]:
+        if not self._local_settings_cache.is_valid:
+            # TODO import 'get_addon_site_settings' when available
+            #   in public 'ayon_api'
+            con = ayon_api.get_server_api_connection()
+            self._local_settings_cache.update_data(
+                con.get_addon_site_settings(
+                    self.name, self.version
+                )
+            )
+        return self._local_settings_cache.get_data()
+
     def _get_server_user_auth(
         self,
         server_info: Dict[str, Any],
@@ -258,17 +270,8 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
 
         require_authentication = server_info["require_authentication"]
         if require_authentication:
-            con = ayon_api.get_server_api_connection()
             if local_settings is None:
-                # TODO import 'get_addon_site_settings' when available
-                #   in public 'ayon_api'
-                if not self._local_settings_cache.is_valid:
-                    self._local_settings_cache.update_data(
-                        con.get_addon_site_settings(
-                            self.name, self.version
-                        )
-                    )
-                local_settings = self._local_settings_cache.get_data()
+                local_setting = self._get_local_settings()
 
             for server_info in local_settings["local_settings"]:
                 if server_name != server_info["server_name"]:

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -128,7 +128,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         if not response.ok:
             raise ValueError("Failed to create job")
 
-        payload["job_id"] = response.json()["_id"]
+        payload["response"] = response.json()
         return payload
 
     def submit_ayon_plugin_job(

--- a/client/ayon_deadline/constants.py
+++ b/client/ayon_deadline/constants.py
@@ -1,0 +1,2 @@
+# Version of Deadline 'Ayon' plugin
+AYON_PLUGIN_VERSION = "1.0.0"

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -1,5 +1,4 @@
-import json
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, fields
 from functools import partial
 import typing
 from typing import Optional, List, Tuple, Any, Dict, Iterable
@@ -578,13 +577,6 @@ class DeadlineJobInfo:
 
         super().__setattr__(key, value)
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
-    def to_json(self) -> str:
-        """Serialize the dataclass instance to a JSON string."""
-        return json.dumps(self.to_dict())
-
     def serialize(self):
         """Return all data serialized as dictionary.
 
@@ -593,8 +585,9 @@ class DeadlineJobInfo:
 
         """
         output = {}
-        for key, value in tuple(self.to_dict().items()):
-            value = self._serialize_key_value(key, value)
+        for field in fields(self):
+            key = field.name
+            value = self._serialize_key_value(field.name, getattr(self, key))
             if value is not None:
                 output[key] = value
         return output

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -32,6 +32,15 @@ JOB_ENV_DATA_KEY: str = "farmJobEnv"
 
 
 @dataclass
+class DeadlineConnectionInfo:
+    """Connection information for Deadline server."""
+    name: str
+    url: str
+    auth: Tuple[str, str]
+    verify: bool
+
+
+@dataclass
 class DeadlineServerInfo:
     pools: List[str]
     limit_groups: List[str]

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -310,6 +310,14 @@ class DeadlineIndexedVar(dict):
         dict.__setitem__(self, key, value)
 
 
+def _partial_key_value(key: str):
+    return partial(DeadlineKeyValueVar, key)
+
+
+def _partial_indexed(key: str):
+    return partial(DeadlineIndexedVar, key)
+
+
 @dataclass
 class DeadlineJobInfo:
     """Mapping of all Deadline JobInfo attributes.
@@ -328,8 +336,8 @@ class DeadlineJobInfo:
     Comment: Optional[str] = field(default=None)  # default: empty
     Department: Optional[str] = field(default=None)  # default: empty
     BatchName: Optional[str] = field(default=None)  # default: empty
-    UserName: str = field(default=None)
-    MachineName: str = field(default=None)
+    UserName: Optional[str] = field(default=None)
+    MachineName: Optional[str] = field(default=None)
     Pool: Optional[str] = field(default=None)  # default: "none"
     SecondaryPool: Optional[str] = field(default=None)
     Group: Optional[str] = field(default=None)  # default: "none"
@@ -345,7 +353,7 @@ class DeadlineJobInfo:
     Sequential: Optional[bool] = field(default=None)  # default: false
     SuppressEvents: Optional[bool] = field(default=None)  # default: false
     Protected: Optional[bool] = field(default=None)  # default: false
-    InitialStatus: str = field(default="Active")
+    InitialStatus: "InitialStatus" = field(default="Active")
     NetworkRoot: Optional[str] = field(default=None)
 
     # Timeouts
@@ -452,33 +460,32 @@ class DeadlineJobInfo:
         default=None)  # Default blank (comma-separated list)
 
     # Environment
-    EnvironmentKeyValue: Any = field(
-        default_factory=partial(DeadlineKeyValueVar, "EnvironmentKeyValue"))
+    EnvironmentKeyValue: DeadlineKeyValueVar = field(
+        default_factory=_partial_key_value("EnvironmentKeyValue"))
     IncludeEnvironment: Optional[bool] = field(default=False)  # Default: false
     UseJobEnvironmentOnly: Optional[bool] = field(default=False)  # Default: false
     CustomPluginDirectory: Optional[str] = field(default=None)  # Default blank
 
     # Job Extra Info
-    ExtraInfo: Any = field(
-        default_factory=partial(DeadlineIndexedVar, "ExtraInfo"))
-    ExtraInfoKeyValue: Any = field(
-        default_factory=partial(DeadlineKeyValueVar, "ExtraInfoKeyValue"))
+    ExtraInfo: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("ExtraInfo"))
+    ExtraInfoKeyValue: DeadlineKeyValueVar = field(
+        default_factory=_partial_key_value("ExtraInfoKeyValue"))
 
-    OverrideTaskExtraInfoNames: Optional[bool] = field(
-        default=False)  # Default false
+    OverrideTaskExtraInfoNames: Optional[bool] = field(default=False)  # Default false
 
-    TaskExtraInfoName: Any = field(
-        default_factory=partial(DeadlineIndexedVar, "TaskExtraInfoName"))
+    TaskExtraInfoName: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("TaskExtraInfoName"))
 
-    OutputFilename: Any = field(
-        default_factory=partial(DeadlineIndexedVar, "OutputFilename"))
-    OutputFilenameTile: str = field(
-        default_factory=partial(DeadlineIndexedVar, "OutputFilename{}Tile"))
-    OutputDirectory: str = field(
-        default_factory=partial(DeadlineIndexedVar, "OutputDirectory"))
+    OutputFilename: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("OutputFilename"))
+    OutputFilenameTile: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("OutputFilename{}Tile"))
+    OutputDirectory: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("OutputDirectory"))
 
-    AssetDependency: str = field(
-        default_factory=partial(DeadlineIndexedVar, "AssetDependency"))
+    AssetDependency: DeadlineIndexedVar = field(
+        default_factory=_partial_indexed("AssetDependency"))
 
     TileJob: bool = field(default=False)
     TileJobFrame: int = field(default=0)

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -3,6 +3,7 @@ import json
 from dataclasses import dataclass, field, asdict
 from functools import partial
 from typing import Optional, List, Tuple, Any, Dict
+from enum import Enum
 
 import requests
 
@@ -60,6 +61,31 @@ def get_instance_job_envs(instance) -> "dict[str, str]":
         env = dict(sorted(env.items()))
 
     return env
+
+
+class JobType(str, Enum):
+    UNDEFINED = "undefined"
+    RENDER = "render"
+    PUBLISH = "publish"
+    REMOTE = "remote"
+
+    def get_job_env(self) -> Dict[str, str]:
+        return {
+            "AYON_PUBLISH_JOB": str(int(self == JobType.PUBLISH)),
+            "AYON_RENDER_JOB": str(int(self == JobType.RENDER)),
+            "AYON_REMOTE_PUBLISH": str(int(self == JobType.REMOTE)),
+        }
+
+    @classmethod
+    def get(
+        cls, value: Any, default: Optional[Any] = None
+    ) -> "JobType":
+        try:
+            return cls(value)
+        except ValueError:
+            if default is None:
+                return cls.UNDEFINED
+            return default
 
 
 def get_deadline_pools(

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -585,9 +585,9 @@ class DeadlineJobInfo:
 
         """
         output = {}
-        for field in fields(self):
+        for field_item in fields(self):
             self._fill_serialize_value(
-                field.name, getattr(self, field.name), output
+                field_item.name, getattr(self, field_item.name), output
             )
         return output
 

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -291,22 +291,33 @@ class DeadlineIndexedVar(dict):
             i += 1
         return i
 
-    def update(self, data):
+    def add(self, value: str):
+        if value not in self.values():
+            self.append(value)
+
+    def append(self, value: str):
+        index = self.next_available_index()
+        self[index] = value
+
+    def extend(self, values: Iterable[str]):
+        for value in values:
+            self.append(value)
+
+    def update(self, data: Dict[int, str]):
         # Force the integer key check
         for key, value in data.items():
             self.__setitem__(key, value)
 
-    def __iadd__(self, other):
-        index = self.next_available_index()
-        self[index] = other
+    def __iadd__(self, value: str):
+        self.append(value)
         return self
 
     def __setitem__(self, key, value):
         if not isinstance(key, int):
-            raise TypeError("Key must be an integer: {}".format(key))
+            raise TypeError(f"Key must be an 'int', got {type(key)} ({key}).")
 
         if key < 0:
-            raise ValueError("Negative index can't be set: {}".format(key))
+            raise ValueError(f"Negative index can't be set: {key}")
         dict.__setitem__(self, key, value)
 
 

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -508,6 +508,81 @@ class DeadlineJobInfo:
     MaintenanceJobStartFrame: int = field(default=0)
     MaintenanceJobEndFrame: int = field(default=0)
 
+    def __post_init__(self):
+        for attr_name in (
+            "JobDependencies",
+            "Whitelist",
+            "Blacklist",
+            "LimitGroups",
+        ):
+            value = getattr(self, attr_name)
+            if value is None:
+                continue
+            if not isinstance(value, list):
+                setattr(self, attr_name, value)
+
+        for attr_name in (
+            "ExtraInfo",
+            "TaskExtraInfoName",
+            "OutputFilename",
+            "OutputFilenameTile",
+            "OutputDirectory",
+            "AssetDependency",
+        ):
+            value = getattr(self, attr_name)
+            if value is None:
+                continue
+            if not isinstance(value, DeadlineIndexedVar):
+                setattr(self, attr_name, value)
+
+        for attr_name in (
+            "ExtraInfoKeyValue",
+            "EnvironmentKeyValue",
+        ):
+            value = getattr(self, attr_name)
+            if value is None:
+                continue
+            if not isinstance(value, DeadlineKeyValueVar):
+                setattr(self, attr_name, value)
+
+    def __setattr__(self, key, value):
+        if value is None:
+            super().__setattr__(key, value)
+            return
+
+        if key in (
+            "JobDependencies",
+            "Whitelist",
+            "Blacklist",
+            "LimitGroups",
+        ):
+            if isinstance(value, str):
+                value = value.split(",")
+
+        elif key in (
+            "ExtraInfo",
+            "TaskExtraInfoName",
+            "OutputFilename",
+            "OutputFilenameTile",
+            "OutputDirectory",
+            "AssetDependency",
+        ):
+            if not isinstance(value, DeadlineIndexedVar):
+                new_value = DeadlineIndexedVar(key)
+                new_value.update(value)
+                value = new_value
+
+        elif key in (
+            "ExtraInfoKeyValue",
+            "EnvironmentKeyValue",
+        ):
+            if not isinstance(value, DeadlineKeyValueVar):
+                new_value = DeadlineKeyValueVar(key)
+                new_value.update(value)
+                value = new_value
+
+        super().__setattr__(key, value)
+
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -240,20 +240,17 @@ class DeadlineKeyValueVar(dict):
 
 
     """
-    def __init__(self, key):
-        super(DeadlineKeyValueVar, self).__init__()
-        self.__key = key
+    def __init__(self, key: str):
+        super().__init__()
+        if not key.endswith("{}"):
+            key += "{}"
+        self._key = key
 
     def serialize(self):
-        key = self.__key
-
         # Allow custom location for index in serialized string
-        if "{}" not in key:
-            key = key + "{}"
-
         return {
-            key.format(index): "{}={}".format(var_key, var_value)
-            for index, (var_key, var_value) in enumerate(sorted(self.items()))
+            self._key.format(idx): f"{key}={value}"
+            for idx, (key, value) in enumerate(sorted(self.items()))
         }
 
 
@@ -265,23 +262,20 @@ class DeadlineIndexedVar(dict):
         Set: var[1] = "my_value"
         Append: var += "value"
 
-    Note: Iterating the instance is not guarantueed to be the order of the
+    Note: Iterating the instance is not guaranteed to be the order of the
           indices. To do so iterate with `sorted()`
 
     """
-    def __init__(self, key):
-        super(DeadlineIndexedVar, self).__init__()
-        self.__key = key
-
-    def serialize(self):
-        key = self.__key
-
-        # Allow custom location for index in serialized string
+    def __init__(self, key: str):
+        super().__init__()
         if "{}" not in key:
-            key = key + "{}"
+            key += "{}"
+        self._key = key
 
+    def serialize(self) -> Dict[str, str]:
         return {
-            key.format(index): value for index, value in sorted(self.items())
+            self._key.format(index): value
+            for index, value in sorted(self.items())
         }
 
     def next_available_index(self):

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -633,7 +633,9 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
 
     def add_render_job_env_var(self):
         """Add required env vars for valid render job submission."""
-        self.EnvironmentKeyValue["AYON_RENDER_JOB"] = "1"
+        self.EnvironmentKeyValue.update(
+            JobType.RENDER.get_job_env()
+        )
 
     def add_instance_job_env_vars(self, instance):
         """Add all job environments as specified on the instance and context

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -412,7 +412,7 @@ class DeadlineJobInfo:
     LimitGroups: Optional[List[str]] = field(default_factory=list)  # Default: blank
 
     # Dependencies
-    JobDependencies: Optional[str] = field(default=None)  # Default: blank
+    JobDependencies: List[str] = field(default_factory=list)  # Default: blank
     JobDependencyPercentage: Optional[int] = field(default=None)  # Default: -1
     IsFrameDependent: Optional[bool] = field(default=None)  # Default: false
     FrameDependencyOffsetStart: Optional[int] = field(default=None)  # Default: 0

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -83,7 +83,7 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
         self, instance: pyblish.api.Instance,
         deadline_url: str,
     ) -> Optional[str]:
-        """Find server name from project settings nased on url.
+        """Find server name from project settings based on url.
 
         Args:
             instance (pyblish.api.Instance): Instance object.

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -1,12 +1,25 @@
 # -*- coding: utf-8 -*-
-"""Collect Deadline servers from instance.
+"""Collect Deadline server information from instance.
 
-This is resolving index of server lists stored in `deadlineServers` instance
-attribute or using default server if that attribute doesn't exists.
+This module collects Deadline Webservice name and URL for instance.
+Based on data stored on instance a deadline information is stored to instance
+data.
+
+For maya this is resolving index of server lists stored in `deadlineServers`
+instance attribute or using default server if that attribute doesn't exists.
+That happens for backwards compatibility and should be removed in future
+releases.
+
+TODOS:
+- Remove backwards compatibility for `deadlineServers` attribute.
+- Remove backwards compatibility for `deadlineUrl` attribute.
+- Don't store deadline url, but use server name instead.
 
 """
+from typing import Optional, Tuple
+
 import pyblish.api
-from ayon_core.pipeline.publish import KnownPublishError
+from ayon_core.pipeline.publish import KnownPublishError, PublishError
 
 from ayon_deadline.lib import FARM_FAMILIES
 
@@ -26,25 +39,75 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             self.log.debug("Should not be processed on farm, skipping.")
             return
 
-        if not instance.data.get("deadline"):
-            instance.data["deadline"] = {}
+        instance_deadline_info = instance.data.setdefault("deadline", {})
 
-        # todo: separate logic should be removed, all hosts should have same
-        host_name = instance.context.data["hostName"]
+        context = instance.context
+        host_name = context.data["hostName"]
+        # TODO: Host specific logic should be avoided
+        #   - all hosts should have same data structure on instances
         if host_name == "maya":
-            deadline_url = self._collect_deadline_url(instance)
+            deadline_url, server_name = self._collect_maya_deadline_server(instance)
         else:
-            deadline_url = (instance.data.get("deadlineUrl") or  # backwards
-                            instance.data.get("deadline", {}).get("url"))
-        if deadline_url:
-            instance.data["deadline"]["url"] = deadline_url.strip().rstrip("/")
-        else:
-            instance.data["deadline"]["url"] = instance.context.data["deadline"]["defaultUrl"]  # noqa
-        self.log.debug(
-            "Using {} for submission".format(instance.data["deadline"]["url"]))
+            # TODO remove backwards compatibility
+            deadline_url = instance.data.get("deadlineUrl")
+            server_name = None
+            if not deadline_url:
+                deadline_url = instance_deadline_info.get("url")
+                server_name = instance_deadline_info.get("serverName")
 
-    def _collect_deadline_url(self, render_instance):
-        # type: (pyblish.api.Instance) -> str
+            if not server_name:
+                server_name = self._find_server_name(
+                    instance, deadline_url
+                )
+
+        if not deadline_url:
+            context_deadline_info = context.data["deadline"]
+            deadline_url = context_deadline_info["defaultUrl"]
+            server_name = context_deadline_info["defaultServerName"]
+
+        if not server_name:
+            raise PublishError(
+                f"Collected deadline URL '{deadline_url}' does not match any"
+                f" existing deadline servers configured in Studio Settings."
+            )
+
+        deadline_url = deadline_url.strip().rstrip("/")
+        instance_deadline_info["url"] = deadline_url
+        # TODO prefer server name over url
+        instance_deadline_info["serverName"] = server_name
+
+        self.log.debug(
+            f"Server '{server_name}' ({deadline_url})"
+            " will be used for submission."
+        )
+
+    def _find_server_name(
+        self, instance: pyblish.api.Instance,
+        deadline_url: str,
+    ) -> Optional[str]:
+        """Find server name from project settings nased on url.
+
+        Args:
+            instance (pyblish.api.Instance): Instance object.
+            deadline_url (str): Deadline Webservice URL.
+
+        Returns:
+            Optional[str]: Deadline server name.
+
+        """
+        deadline_url = deadline_url.strip().rstrip("/")
+
+        deadline_settings = (
+            instance.context.data["project_settings"]["deadline"]
+        )
+        for server_info in deadline_settings["deadline_servers_info"]:
+            if server_info["value"].strip().rstrip("/") == deadline_url:
+                return server_info["name"]
+        return None
+
+    def _collect_maya_deadline_server(
+        self, render_instance: pyblish.api.Instance
+    ) -> Tuple[str, str]:
         """Get Deadline Webservice URL from render instance.
 
         This will get all configured Deadline Webservice URLs and create
@@ -57,23 +120,24 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
                 by Creator in Maya.
 
         Returns:
-            str: Selected Deadline Webservice URL.
+            tuple[str, str]: Selected Deadline Webservice URL.
 
         """
-        # Not all hosts can import this module.
         from maya import cmds
+
         deadline_settings = (
             render_instance.context.data
             ["project_settings"]
             ["deadline"]
         )
-        default_server_url = (render_instance.context.data["deadline"]
-                                                          ["defaultUrl"])
         # QUESTION How and where is this is set? Should be removed?
         instance_server = render_instance.data.get("deadlineServers")
         if not instance_server:
+            context_deadline_info = render_instance.context.data["deadline"]
+            default_server_url = context_deadline_info["defaultUrl"]
+            default_server_name = context_deadline_info["defaultServerName"]
             self.log.debug("Using default server.")
-            return default_server_url
+            return default_server_url, default_server_name
 
         # Get instance server as sting.
         if isinstance(instance_server, int):
@@ -86,22 +150,17 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             url_item["name"]: url_item["value"]
             for url_item in deadline_settings["deadline_servers_info"]
         }
-        project_servers = (
-            render_instance.context.data
-            ["project_settings"]
-            ["deadline"]
-            ["deadline_servers"]
-        )
+        project_servers = deadline_settings["deadline_servers"]
         if not project_servers:
             self.log.debug("Not project servers found. Using default servers.")
-            return default_servers[instance_server]
+            return default_servers[instance_server], instance_server
 
+        # TODO create validation plugin for this check
         project_enabled_servers = {
             k: default_servers[k]
             for k in project_servers
             if k in default_servers
         }
-
         if instance_server not in project_enabled_servers:
             msg = (
                 "\"{}\" server on instance is not enabled in project settings."
@@ -112,4 +171,4 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             raise KnownPublishError(msg)
 
         self.log.debug("Using project approved server.")
-        return project_enabled_servers[instance_server]
+        return project_enabled_servers[instance_server], instance_server

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -47,7 +47,9 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
         #   - all hosts should have same data structure on instances
         server_name = None
         if host_name == "maya":
-            deadline_url, server_name = self._collect_maya_deadline_server(instance)
+            deadline_url, server_name = self._collect_maya_deadline_server(
+                instance
+            )
         else:
             # TODO remove backwards compatibility
             deadline_url = instance.data.get("deadlineUrl")

--- a/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
@@ -23,11 +23,7 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
     targets = ["local"]
 
     def process(self, context):
-        try:
-            deadline_addon = context.data["ayonAddonsManager"]["deadline"]
-        except AttributeError:
-            self.log.error("Cannot get AYON Deadline addon.")
-            raise AssertionError("AYON Deadline addon not found.")
+        deadline_addon = context.data["ayonAddonsManager"]["deadline"]
 
         deadline_settings = context.data["project_settings"]["deadline"]
         deadline_server_name = deadline_settings["deadline_server"]
@@ -44,6 +40,7 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
             default_dl_server_info = deadline_addon.deadline_servers_info[key]
             deadline_url = default_dl_server_info["value"]
 
-        context.data["deadline"] = {}
-        context.data["deadline"]["defaultUrl"] = (
-            deadline_url.strip().rstrip("/"))
+        context.data["deadline"] = {
+            "defaultUrl": deadline_url.strip().rstrip("/"),
+            "defaultServerName": deadline_server_name,
+        }

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -56,14 +56,15 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
 
         self._handle_additional_jobinfo(attr_values, job_info)
 
-        instance.data["deadline"]["job_info"] = job_info
-
         # pass through explicitly key and values for PluginInfo
         plugin_info_data = None
         if attr_values["additional_plugin_info"]:
             plugin_info_data = json.loads(
                 attr_values["additional_plugin_info"]
             )
+
+        deadline_info = instance.data["deadline"]
+        deadline_info["job_info"] = job_info
         deadline_info["plugin_info_data"] = plugin_info_data
 
         self._add_deadline_families(instance)

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -15,7 +15,7 @@ from ayon_core.addon import AddonsManager
 
 from ayon_deadline.lib import (
     FARM_FAMILIES,
-    AYONDeadlineJobInfo,
+    PublishDeadlineJobInfo,
     DeadlineWebserviceError,
 )
 
@@ -50,7 +50,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         attr_values = self._get_jobinfo_defaults(instance)
 
         attr_values.update(self.get_attr_values_from_data(instance.data))
-        job_info = AYONDeadlineJobInfo.from_dict(attr_values)
+        job_info = PublishDeadlineJobInfo.from_attribute_values(attr_values)
 
         self._handle_machine_list(attr_values, job_info)
 
@@ -61,9 +61,10 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         # pass through explicitly key and values for PluginInfo
         plugin_info_data = None
         if attr_values["additional_plugin_info"]:
-            plugin_info_data = (
-                json.loads(attr_values["additional_plugin_info"]))
-        instance.data["deadline"]["plugin_info_data"] = plugin_info_data
+            plugin_info_data = json.loads(
+                attr_values["additional_plugin_info"]
+            )
+        deadline_info["plugin_info_data"] = plugin_info_data
 
         self._add_deadline_families(instance)
 

--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -49,16 +49,22 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
         if not collected_deadline_url:
             raise ValueError("Instance doesn't have '[deadline][url]'.")
         context_data = instance.context.data
-        deadline_settings = context_data["project_settings"]["deadline"]
 
-        deadline_server_name = None
+
         # deadline url might be set directly from instance, need to find
         # metadata for it
-        for deadline_info in deadline_settings["deadline_urls"]:
-            dl_settings_url = deadline_info["value"].strip().rstrip("/")
-            if dl_settings_url == collected_deadline_url:
-                deadline_server_name = deadline_info["name"]
-                break
+        deadline_server_name = instance.data["deadline"].get("serverName")
+        if deadline_server_name is None:
+            self.log.warning(
+                "DEV WARNING: Instance does not have set"
+                " instance['deadline']['serverName']."
+            )
+            deadline_settings = context_data["project_settings"]["deadline"]
+            for deadline_info in deadline_settings["deadline_urls"]:
+                dl_settings_url = deadline_info["value"].strip().rstrip("/")
+                if dl_settings_url == collected_deadline_url:
+                    deadline_server_name = deadline_info["name"]
+                    break
 
         if not deadline_server_name:
             raise ValueError(f"Collected {collected_deadline_url} doesn't "

--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -50,33 +50,41 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
             raise ValueError("Instance doesn't have '[deadline][url]'.")
         context_data = instance.context.data
 
-
         # deadline url might be set directly from instance, need to find
         # metadata for it
         deadline_server_name = instance.data["deadline"].get("serverName")
+        dealine_info_by_server_name = {
+            deadline_info["name"]: deadline_info
+            for deadline_info in (
+                context_data["project_settings"]["deadline"]["deadline_urls"]
+            )
+        }
         if deadline_server_name is None:
             self.log.warning(
                 "DEV WARNING: Instance does not have set"
                 " instance['deadline']['serverName']."
             )
-            deadline_settings = context_data["project_settings"]["deadline"]
-            for deadline_info in deadline_settings["deadline_urls"]:
+            for deadline_info in dealine_info_by_server_name.values():
                 dl_settings_url = deadline_info["value"].strip().rstrip("/")
                 if dl_settings_url == collected_deadline_url:
                     deadline_server_name = deadline_info["name"]
                     break
 
         if not deadline_server_name:
-            raise ValueError(f"Collected {collected_deadline_url} doesn't "
-                              "match any site configured in Studio Settings")
+            raise ValueError(
+                f"Collected {collected_deadline_url} doesn't"
+                " match any site configured in Studio Settings"
+            )
 
+        deadline_info = dealine_info_by_server_name[deadline_server_name]
         instance.data["deadline"]["require_authentication"] = (
             deadline_info["require_authentication"]
         )
         instance.data["deadline"]["auth"] = None
 
         instance.data["deadline"]["verify"] = (
-            not deadline_info["not_verify_ssl"])
+            not deadline_info["not_verify_ssl"]
+        )
 
         if not deadline_info["require_authentication"]:
             return
@@ -88,8 +96,9 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
         default_password = deadline_info["default_password"]
         if default_username and default_password:
             self.log.debug("Setting credentials from defaults")
-            instance.data["deadline"]["auth"] = (default_username,
-                                                 default_password)
+            instance.data["deadline"]["auth"] = (
+                default_username, default_password
+            )
 
         # TODO import 'get_addon_site_settings' when available
         #   in public 'ayon_api'

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -146,7 +146,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
     skip_integration_repre_list = []
 
     def _submit_deadline_post_job(
-        self, instance, render_job, instances
+        self, instance, render_job, instances, rootless_metadata_path
     ):
         """Submit publish job to Deadline.
 
@@ -175,12 +175,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             context,
             instances[0]["productType"],
             override_version
-        )
-
-        # Transfer the environment from the original job to this dependent
-        # job so they use the same environment
-        metadata_path, rootless_metadata_path = create_metadata_path(
-            instance, anatomy
         )
 
         environment = get_instance_job_envs(instance)
@@ -400,8 +394,14 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
                 "Cannot continue without valid Deadline submission."
             )
 
+        # Transfer the environment from the original job to this dependent
+        # job so they use the same environment
+        metadata_path, rootless_metadata_path = create_metadata_path(
+            instance, anatomy
+        )
+
         deadline_publish_job_id = self._submit_deadline_post_job(
-            instance, render_job, instances
+            instance, render_job, instances, rootless_metadata_path
         )
 
         # Inject deadline url to instances to query DL for job id for overrides
@@ -430,9 +430,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         audio_file = instance.context.data.get("audioFile")
         if audio_file and os.path.isfile(audio_file):
             publish_job.update({"audio": audio_file})
-
-        metadata_path, rootless_metadata_path = \
-            create_metadata_path(instance, anatomy)
 
         with open(metadata_path, "w") as f:
             json.dump(publish_job, f, indent=4, sort_keys=True)

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -180,11 +180,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             create_metadata_path(instance, anatomy)
 
         environment = get_instance_job_envs(instance)
-        environment.update({
-            "AYON_PUBLISH_JOB": "1",
-            "AYON_RENDER_JOB": "0",
-            "AYON_REMOTE_PUBLISH": "0",
-        })
+        environment.update(JobType.PUBLISH.get_job_env())
 
         priority = self.deadline_priority or instance.data.get("priority", 50)
 
@@ -225,7 +221,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
-        environment.update(JobType.PUBLISH.get_job_env())
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=job["Props"]["Batch"],

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -131,7 +131,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
     # custom deadline attributes
     deadline_department = ""
     deadline_pool = ""
-    deadline_pool_secondary = ""
     deadline_group = ""
     deadline_priority = None
 
@@ -225,16 +224,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         if settings_variant == "staging":
             args.append("--use-staging")
 
-        # QUESTION: Shouldn't this be opposite?
-        #   - first instance and then "default pool"
-        primary_pool = self.deadline_pool or instance.data.get("primaryPool")
-        # QUESTION: Why is secondary pool not used?
-        #    - it was always removed in previous code
-        # secondary_pool = (
-        #     self.deadline_pool_secondary
-        #     or instance.data.get("secondaryPool")
-        # )
-
         # Collect dependent jobs
         dependency_ids = None
         if instance.data.get("tileRendering"):
@@ -265,7 +254,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             priority=priority,
             initial_status=initial_status,
             group=self.deadline_group,
-            pool=primary_pool,
+            pool=self.deadline_pool or None,
             dependency_job_ids=dependency_ids,
             output_directories=[output_dir.replace("\\", "/")],
             username=job["Props"]["User"],

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -241,7 +241,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             server_name,
             args,
             job_info
-        )["job_id"]
+        )["response"]["_id"]
 
     def process(self, instance):
         # type: (pyblish.api.Instance) -> None

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -260,7 +260,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             username=job["Props"]["User"],
             comment=context.data.get("comment"),
             env=environment,
-        )
+        )["job_id"]
 
     def process(self, instance):
         # type: (pyblish.api.Instance) -> None

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -230,10 +230,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         primary_pool = self.deadline_pool or instance.data.get("primaryPool")
         # QUESTION: Why is secondary pool not used?
         #    - it was always removed in previous code
-        secondary_pool = (
-            self.deadline_pool_secondary
-            or instance.data.get("secondaryPool")
-        )
+        # secondary_pool = (
+        #     self.deadline_pool_secondary
+        #     or instance.data.get("secondaryPool")
+        # )
+
         # Collect dependent jobs
         dependency_ids = None
         if instance.data.get("tileRendering"):

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -210,6 +210,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         settings_variant = os.environ["AYON_DEFAULT_SETTINGS_VARIANT"]
         if settings_variant == "staging":
             args.append("--use-staging")
+        elif settings_variant != "production":
+            args.extend(["--bundle", settings_variant])
 
         server_name = instance.data["deadline"]["serverName"]
         self.log.debug("Submitting Deadline publish job ...")

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -194,8 +194,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
 
         args = [
             "--headless",
-            'publish',
-            '"{}"'.format(rootless_metadata_path),
+            "publish",
+            rootless_metadata_path,
             "--targets", "deadline",
             "--targets", "farm",
         ]

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -20,6 +20,7 @@ from ayon_core.pipeline.farm.pyblish_functions import (
     prepare_representations,
     create_metadata_path
 )
+from ayon_deadline.constants import AYON_PLUGIN_VERSION
 from ayon_deadline.abstract_submit_deadline import requests_post
 
 
@@ -148,7 +149,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
 
     # list of family names to transfer to new family if present
     families_transfer = ["render3d", "render2d", "slate"]
-    plugin_pype_version = "3.0"
 
     # poor man exclusion
     skip_integration_repre_list = []
@@ -248,7 +248,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
                 "OutputDirectory0": output_dir.replace("\\", "/")
             },
             "PluginInfo": {
-                "Version": self.plugin_pype_version,
+                "Version": AYON_PLUGIN_VERSION,
                 "Arguments": " ".join(args),
                 "SingleFrameOnly": "True",
             },

--- a/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
@@ -1,12 +1,10 @@
 import os
-import requests
 from collections.abc import Iterable
 
 import pyblish.api
 import clique
 
 from ayon_core.pipeline import PublishValidationError
-from ayon_deadline.abstract_submit_deadline import requests_get
 
 
 class ValidateExpectedFiles(pyblish.api.InstancePlugin):

--- a/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import pyblish.api
 import clique
 
+from ayon_core.pipeline import PublishValidationError
 from ayon_deadline.abstract_submit_deadline import requests_get
 
 
@@ -200,31 +201,15 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
             (dict): Job info from Deadline
 
         """
-        deadline_url = instance.data["deadline"]["url"]
-        assert deadline_url, "Requires Deadline Webservice URL"
+        server_name = instance.data["deadline"]["serverName"]
+        if not server_name:
+            raise PublishValidationError(
+                "Deadline server name is not filled."
+            )
 
-        url = "{}/api/jobs?JobID={}".format(deadline_url, job_id)
-        try:
-            kwargs = {}
-            auth = instance.data["deadline"]["auth"]
-            if auth:
-                kwargs["auth"] = auth
-            response = requests_get(url, **kwargs)
-        except requests.exceptions.ConnectionError:
-            self.log.error("Deadline is not accessible at "
-                           "{}".format(deadline_url))
-            return {}
-
-        if not response.ok:
-            self.log.error("Submission failed!")
-            self.log.error(response.status_code)
-            self.log.error(response.content)
-            raise RuntimeError(response.text)
-
-        json_content = response.json()
-        if json_content:
-            return json_content.pop()
-        return {}
+        addons_manager = instance.context.data["ayonAddonsManager"]
+        deadline_addon = addons_manager["deadline"]
+        return deadline_addon.get_job_info(server_name, job_id)
 
     def _get_existing_files(self, staging_dir):
         """Returns set of existing file names from 'staging_dir'"""

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -225,7 +225,7 @@ class HoudiniSubmitDeadline(
 
         # Add dependencies if given
         if dependency_job_ids:
-            job_info.JobDependencies = ",".join(dependency_job_ids)
+            job_info.JobDependencies = dependency_job_ids
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -77,7 +77,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
     # custom deadline attributes
     deadline_department = ""
     deadline_pool = ""
-    deadline_pool_secondary = ""
     deadline_group = ""
     deadline_priority = None
 
@@ -153,16 +152,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             "--targets", "farm"
         ]
 
-        # Generate the payload for Deadline submission
-        # QUESTION: Shouldn't this be opposite?
-        #   - first instance and then "default pool"
-        primary_pool = self.deadline_pool or instance.data.get("primaryPool")
-        # QUESTION: Why is secondary pool not used?
-        #    - it was always removed in previous code
-        # secondary_pool = (
-        #     self.deadline_pool_secondary or instance.data.get("secondaryPool")
-        # )
-
         dependency_ids = []
         if job.get("_id"):
             dependency_ids.append(job["_id"])
@@ -183,7 +172,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             priority=priority,
             initial_status=initial_status,
             group=self.deadline_group,
-            pool=primary_pool,
+            pool=self.deadline_pool or None,
             dependency_job_ids=dependency_ids,
             output_directories=[output_dir.replace("\\", "/")],
             username=job["Props"]["User"],

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -178,7 +178,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             username=job["Props"]["User"],
             comment=context.data.get("comment"),
             env=environment,
-        )
+        )["job_id"]
 
     def process(self, instance):
         # type: (pyblish.api.Instance) -> None

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -122,7 +122,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         args = [
             "--headless",
             'publish',
-            '"{}"'.format(rootless_metadata_path),
+            rootless_metadata_path,
             "--targets", "deadline",
             "--targets", "farm"
         ]

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -18,6 +18,7 @@ from ayon_core.pipeline.farm.pyblish_functions import (
     prepare_cache_representations,
     create_metadata_path
 )
+from ayon_deadline.constants import AYON_PLUGIN_VERSION
 from ayon_deadline.abstract_submit_deadline import requests_post
 
 
@@ -81,8 +82,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
 
     # regex for finding frame number in string
     R_FRAME_NUMBER = re.compile(r'.+\.(?P<frame>[0-9]+)\..+')
-
-    plugin_pype_version = "3.0"
 
     def _submit_deadline_post_job(self, instance, job):
         """Submit publish job to Deadline.
@@ -176,7 +175,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
                 "OutputDirectory0": output_dir.replace("\\", "/")
             },
             "PluginInfo": {
-                "Version": self.plugin_pype_version,
+                "Version": AYON_PLUGIN_VERSION,
                 "Arguments": " ".join(args),
                 "SingleFrameOnly": "True",
             },

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -157,7 +157,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
 
         return deadline_addon.submit_ayon_plugin_job(
             server_name, args, job_info
-        )["job_id"]
+        )["response"]["_id"]
 
     def process(self, instance):
         # type: (pyblish.api.Instance) -> None

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -20,7 +20,7 @@ from ayon_core.pipeline.farm.pyblish_functions import (
 )
 
 from ayon_deadline import DeadlineAddon
-from ayon_deadline.lib import JobType
+from ayon_deadline.lib import JobType, DeadlineJobInfo
 
 
 class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
@@ -162,22 +162,27 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         deadline_addon: DeadlineAddon = (
             context.data["ayonAddonsManager"]["deadline"]
         )
+
+        environment.update(JobType.PUBLISH.get_job_env())
+        job_info = DeadlineJobInfo(
+            Name=job_name,
+            BatchName=job["Props"]["Batch"],
+            Department=self.deadline_department,
+            Priority=priority,
+            InitialStatus=initial_status,
+            Group=self.deadline_group,
+            Pool=self.deadline_pool or None,
+            JobDependencies=dependency_ids,
+            UserName=job["Props"]["User"],
+            Comment=context.data.get("comment"),
+        )
+        job_info.OutputDirectory.append(
+            output_dir.replace("\\", "/")
+        )
+        job_info.EnvironmentKeyValue.update(environment)
+
         return deadline_addon.submit_ayon_plugin_job(
-            server_name,
-            args,
-            job_name,
-            job["Props"]["Batch"],
-            job_type=JobType.PUBLISH,
-            department=self.deadline_department,
-            priority=priority,
-            initial_status=initial_status,
-            group=self.deadline_group,
-            pool=self.deadline_pool or None,
-            dependency_job_ids=dependency_ids,
-            output_directories=[output_dir.replace("\\", "/")],
-            username=job["Props"]["User"],
-            comment=context.data.get("comment"),
-            env=environment,
+            server_name, args, job_info
         )["job_id"]
 
     def process(self, instance):

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -159,9 +159,10 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         primary_pool = self.deadline_pool or instance.data.get("primaryPool")
         # QUESTION: Why is secondary pool not used?
         #    - it was always removed in previous code
-        secondary_pool = (
-            self.deadline_pool_secondary or instance.data.get("secondaryPool")
-        )
+        # secondary_pool = (
+        #     self.deadline_pool_secondary or instance.data.get("secondaryPool")
+        # )
+
         dependency_ids = []
         if job.get("_id"):
             dependency_ids.append(job["_id"])

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -112,11 +112,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             create_metadata_path(instance, anatomy)
 
         environment = get_instance_job_envs(instance)
-        environment.update({
-            "AYON_PUBLISH_JOB": "1",
-            "AYON_RENDER_JOB": "0",
-            "AYON_REMOTE_PUBLISH": "0",
-        })
+        environment.update(JobType.PUBLISH.get_job_env())
 
         priority = self.deadline_priority or instance.data.get("priority", 50)
 
@@ -142,7 +138,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
-        environment.update(JobType.PUBLISH.get_job_env())
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=job["Props"]["Batch"],

--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
@@ -4,7 +4,7 @@
 This module is taking care of submitting job from Maya to Deadline. It
 creates job and set correct environments. Its behavior is controlled by
 ``DEADLINE_REST_URL`` environment variable - pointing to Deadline Web Service
-and :data:`AYONDeadlineJobInfo.UsePublished` property telling Deadline to
+and :data:`PublishDeadlineJobInfo.use_published` property telling Deadline to
 use published scene workfile or not.
 
 If ``vrscene`` or ``assscene`` are detected in families, it will first
@@ -172,8 +172,8 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         output_dir = os.path.dirname(first_file)
         instance.data["outputDir"] = output_dir
 
-        # Patch workfile (only when UsePublished is enabled)
-        if self.job_info.UsePublished:
+        # Patch workfile (only when 'use_published' is enabled)
+        if self.job_info.use_published:
             self._patch_workfile()
 
         # Gather needed data ------------------------------------------------
@@ -450,8 +450,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     def _get_maya_payload(self, data):
 
         job_info = copy.deepcopy(self.job_info)
-
-        if not is_in_tests() and self.job_info.UseAssetDependencies:
+        if not is_in_tests() and self.job_info.use_asset_dependencies:
             # Asset dependency to wait for at least the scene file to sync.
             job_info.AssetDependency += self.scene_path
 

--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
@@ -214,7 +214,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         # Add export job as dependency --------------------------------------
         if export_job:
             job_info, _ = payload
-            job_info.JobDependencies = export_job
+            job_info.JobDependencies.append(export_job)
 
         if instance.data.get("tileRendering"):
             # Prepare tiles data
@@ -368,7 +368,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
             frame_assembly_job_info.ExtraInfo[0] = file_hash
             frame_assembly_job_info.ExtraInfo[1] = file
-            frame_assembly_job_info.JobDependencies = tile_job_id
+            frame_assembly_job_info.JobDependencies.append(tile_job_id)
             frame_assembly_job_info.Frames = frame
 
             # write assembly job config files

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -71,7 +71,7 @@ class NukeSubmitDeadline(
         self.job_info = self.get_job_info(job_info=job_info)
 
         self._set_scene_path(
-            context.data["currentFile"], job_info.UsePublished)
+            context.data["currentFile"], job_info.use_published)
 
         self.plugin_info = self.get_plugin_info(
             scene_path=self.scene_path,


### PR DESCRIPTION
## Changelog Description
Added api functions to submit deadline jobs using server name from settings.

## Additional review information
Also used new functions in publish jo submission plugins. That required small change in server collection to also store `serverName` to deadline info on instance and context, in future, we could store only server name.

The functionality can be also used for submission of render jobs. New api functions were added to allow other addons trigger AYON plugin jobs without knowing too much.

## Testing notes:
1. It is possible to submit publish job.
2. Submitted publish job should work as before.
