### PR TITLE
Fix names of render jobs for Nuke

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -108,6 +108,8 @@ class NukeSubmitDeadline(
                 scene_path = baking_script["bakeScriptPath"]
                 write_node_name = baking_script["bakeWriteNodeName"]
 
+                self.job_info.Name = os.path.basename(render_path)
+
                 self.plugin_info = self.get_plugin_info(
                     scene_path=scene_path,
                     render_path=render_path,
@@ -138,6 +140,9 @@ class NukeSubmitDeadline(
             )
         limit_groups = self._get_limit_groups(self.node_class_limit_groups)
         job_info.LimitGroups = limit_groups
+
+        render_path = instance.data["path"]
+        job_info.Name = os.path.basename(render_path)
 
         return job_info
 


### PR DESCRIPTION
## Changelog Description
This returns changed render job names to original state. Nuke has different format than the rest.

## Additional Information
Question is, if this naming is not actually better than universal one, where `Batch Name - InstanceName` value is used.

## Testing notes:
1. trigger Nuke Deadline job
2. render jobs should be named according to files they are rendering
![image](https://github.com/user-attachments/assets/43298fe7-879f-4035-b325-c246cf415cfe)
(`renderNuke_compositingMain.baking.mov` vs `ad_sh01_nuke_compositing_v047.nk - renderNuke_compositingMain`)
