### PR TITLE
Fix Maya submit strict error checking and tile priority attributes

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -210,8 +210,6 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             )
         )
 
-        defs.extend(cls._host_specific_attr_defs(create_context, instance))
-
         defs.append(
             UISeparatorDef("deadline_defs_end")
         )
@@ -379,21 +377,3 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             }
         )
         return profile or {}
-
-    @classmethod
-    def _host_specific_attr_defs(cls, create_context, instance):
-        host_name = create_context.host_name
-        if host_name == "maya":
-            return [
-                NumberDef(
-                    "tile_priority",
-                    label="Tile Assembler Priority",
-                    decimals=0,
-                ),
-                BoolDef(
-                    "strict_error_checking",
-                    label="Strict Error Checking",
-                ),
-            ]
-
-        return []

--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
@@ -30,7 +30,7 @@ from ayon_core.pipeline import (
     AYONPyblishPluginMixin
 )
 
-from ayon_core.lib import is_in_tests
+from ayon_core.lib import is_in_tests, NumberDef, BoolDef
 from ayon_core.pipeline.farm.tools import iter_expected_files
 
 from ayon_maya.api.lib_rendersettings import RenderSettings
@@ -101,8 +101,26 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     targets = ["local"]
     settings_category = "deadline"
 
+    strict_error_checking = False
+
     tile_assembler_plugin = "DraftTileAssembler"
     tile_priority = 50
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            NumberDef(
+                "tile_priority",
+                label="Tile Assembler Priority",
+                decimals=0,
+                default=cls.tile_priority
+            ),
+            BoolDef(
+                "strict_error_checking",
+                label="Strict Error Checking",
+                default=cls.strict_error_checking
+            ),
+        ]
 
     def get_job_info(self, job_info=None):
         instance = self._instance


### PR DESCRIPTION
## Changelog Description

Fix Maya submit strict error checking and tile priority attributes

## Additional review information

- They are now adhered to in publisher UI
- They are now based on the SubmitMayaDeadline settings in AYON
- They are now not incorrectly 'hidden' in `JobInfo` instance even though they are Plugin Info attributes

There is the downside that they are now in a not very nice location in the Publisher UI itself (because they are not part of the "Job Info" collector now.

![image](https://github.com/user-attachments/assets/e2fe77bb-d8e2-4c3c-835c-f9470564a0c9)

---

Originally reported on discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1326631657494548482)

## Testing notes:
1. Tweak 'strict error checking' defaults in settings
2. Publisher UI should adhere to those defaults for submitting maya render
3. Submit from Maya
4. The job should adhere to the publisher UI values.