### PR TITLE
Fix Collect Job Info Groups and Limit Groups

### DIFF
--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -75,7 +75,10 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             limit_groups = get_deadline_limit_groups(server_url, auth)
             machines = get_deadline_workers(server_url, auth)
             server_info = DeadlineServerInfo(
-                pools, groups, limit_groups, machines
+                pools=pools,
+                limit_groups=limit_groups,
+                groups=groups,
+                machines=machines
             )
             self._server_info_by_name[server_name] = server_info
 

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -517,14 +517,14 @@ class AYONDeadlineJobInfo(DeadlineJobInfo):
     def from_dict(cls, data: Dict[str, Any]) -> 'AYONDeadlineJobInfo':
 
         implemented_field_values = {
-            "ChunkSize": data.get("chunk_size"),
-            "Priority": data.get("priority"),
-            "MachineLimit": data.get("machine_limit"),
-            "ConcurrentTasks": data.get("concurrent_tasks"),
+            "ChunkSize": data["chunk_size"],
+            "Priority": data["priority"],
+            "MachineLimit": data["machine_limit"],
+            "ConcurrentTasks": data["concurrent_tasks"],
             "Frames": data.get("frames", ""),
-            "Group": cls._sanitize(data.get("group")),
-            "Pool": cls._sanitize(data.get("primary_pool")),
-            "SecondaryPool": cls._sanitize(data.get("secondary_pool")),
+            "Group": cls._sanitize(data["group"]),
+            "Pool": cls._sanitize(data["primary_pool"]),
+            "SecondaryPool": cls._sanitize(data["secondary_pool"]),
 
             # fields needed for logic, values unavailable during collection
             "UsePublished": data["use_published"],

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -517,14 +517,14 @@ class AYONDeadlineJobInfo(DeadlineJobInfo):
     def from_dict(cls, data: Dict[str, Any]) -> 'AYONDeadlineJobInfo':
 
         implemented_field_values = {
-            "ChunkSize": data["chunk_size"],
-            "Priority": data["priority"],
-            "MachineLimit": data["machine_limit"],
-            "ConcurrentTasks": data["concurrent_tasks"],
+            "ChunkSize": data.get("chunk_size"),
+            "Priority": data.get("priority"),
+            "MachineLimit": data.get("machine_limit"),
+            "ConcurrentTasks": data.get("concurrent_tasks"),
             "Frames": data.get("frames", ""),
-            "Group": cls._sanitize(data["group"]),
-            "Pool": cls._sanitize(data["primary_pool"]),
-            "SecondaryPool": cls._sanitize(data["secondary_pool"]),
+            "Group": cls._sanitize(data.get("group")),
+            "Pool": cls._sanitize(data.get("primary_pool")),
+            "SecondaryPool": cls._sanitize(data.get("secondary_pool")),
 
             # fields needed for logic, values unavailable during collection
             "UsePublished": data["use_published"],

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -133,6 +133,9 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 {"value": group, "label": group}
                 for group in server_info.groups
             ]
+            # Always allow no group to be set and insert as first item so
+            # that in edge cases it's selected by default
+            groups.insert(0, {"value": None, "label": ""})
             limit_groups = [
                 {"value": limit_group, "label": limit_group}
                 for limit_group in server_info.limit_groups
@@ -145,7 +148,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             cls.log.warning(f"Unable to connect to {deadline_server_name}")
 
         for items in [
-            pools, groups, limit_groups, machines
+            pools, limit_groups, machines
         ]:
             if not items:
                 items.append({"value": None, "label": "< none >"})

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -129,13 +129,11 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 {"value": pool, "label": pool}
                 for pool in server_info.pools
             ]
+            # Groups always includes the default 'none' group
             groups = [
                 {"value": group, "label": group}
                 for group in server_info.groups
             ]
-            # Always allow no group to be set and insert as first item so
-            # that in edge cases it's selected by default
-            groups.insert(0, {"value": None, "label": ""})
             limit_groups = [
                 {"value": limit_group, "label": limit_group}
                 for limit_group in server_info.limit_groups

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -146,7 +146,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             cls.log.warning(f"Unable to connect to {deadline_server_name}")
 
         for items in [
-            pools, limit_groups, machines
+            pools, groups, limit_groups, machines
         ]:
             if not items:
                 items.append({"value": None, "label": "< none >"})


### PR DESCRIPTION
## Changelog Description

Fix #103 

## Additional review information

Limit Groups and Groups were swapped in the Server Info.

## Testing notes:

1. Expose groups and limit groups in the UI.
2. They should behave accordingly and be correctly submitted along to the job.
