### PR TITLE
Updated ChunkSize for baking jobs to 999999

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -110,6 +110,9 @@ class NukeSubmitDeadline(
 
                 self.job_info.Name = os.path.basename(render_path)
 
+                # baking job shouldn't be split
+                self.job_info.ChunkSize = 999999
+
                 self.plugin_info = self.get_plugin_info(
                     scene_path=scene_path,
                     render_path=render_path,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -61,7 +61,7 @@ class CollectJobInfoItem(BaseSettingsModel):
 
     #########################################
 
-    chunk_size: int = SettingsField(999999, title="Frames per Task")
+    chunk_size: int = SettingsField(999, title="Frames per Task")
     priority: int = SettingsField(50, title="Priority")
     group: str = SettingsField("", title="Group")
     limit_groups: list[str] = SettingsField(
@@ -363,7 +363,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
                 "primary_pool",
                 "secondary_pool"
               ],
-              "chunk_size": 999999,
+              "chunk_size": 999,
               "department": "",
               "host_names": [],
               "task_names": [],

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -61,7 +61,7 @@ class CollectJobInfoItem(BaseSettingsModel):
 
     #########################################
 
-    chunk_size: int = SettingsField(999, title="Frames per Task")
+    chunk_size: int = SettingsField(999999, title="Frames per Task")
     priority: int = SettingsField(50, title="Priority")
     group: str = SettingsField("", title="Group")
     limit_groups: list[str] = SettingsField(
@@ -363,7 +363,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
                 "primary_pool",
                 "secondary_pool"
               ],
-              "chunk_size": 999,
+              "chunk_size": 999999,
               "department": "",
               "host_names": [],
               "task_names": [],


### PR DESCRIPTION
## Changelog Description
Baking job should have only once instance, one task.

## Additional review information
 (sys.maxsize didnt work, hopefully this value will be enough).

## Testing notes:
1. in Nuke set ChunkSize to some small value to actually trigger (eg. it should produce multiple tasks for render job)
2. check that `Baking` job still has only single task, baking whole frame range.
![image](https://github.com/user-attachments/assets/dd32da76-0de0-4cba-b387-5b304dc5a8fc)

