### PR TITLE
Update setting default value for deadline dict on instance

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -39,7 +39,9 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             self.log.debug("Should not be processed on farm, skipping.")
             return
 
-        deadline_info = instance.data.setdefault("deadline", {})
+        if not instance.data.get("deadline"):
+            instance.data["deadline"] = {}
+        deadline_info = instance.data["deadline"]
 
         context = instance.context
         host_name = context.data["hostName"]

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -39,6 +39,7 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             self.log.debug("Should not be processed on farm, skipping.")
             return
 
+        # NOTE: Remove when nothing sets 'deadline' to 'None'
         if not instance.data.get("deadline"):
             # reset if key is None or not available
             instance.data["deadline"] = {}

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -40,6 +40,7 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             return
 
         if not instance.data.get("deadline"):
+            # reset if key is None or not available
             instance.data["deadline"] = {}
         deadline_info = instance.data["deadline"]
 


### PR DESCRIPTION
## Changelog Description
`setdefault` checks only for presence of key, not if value is None, which now happens in Fusion and Unreal. This way is safer, until Fusion/Unreal and default values for RenderInstance are fixed in ayon-core.

## Additional review information
`ayon-core` `RenderInstance` sets `deadline` key to None, but should set it as {}. 

## Testing notes:
1. publish in Fusion/Unreal
2. shouldnt fail in `collect_deadline_server_from_instance`
