### PR TITLE
Job Info Output Directory+Files pass sequence and remap to published workfile if needed

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -170,7 +170,8 @@ class AbstractSubmitDeadline(
         """
         collections, remainder = clique.assemble(
             iter_expected_files(instance.data["expectedFiles"]),
-            assume_padded_when_ambiguous=True)
+            assume_padded_when_ambiguous=True,
+            patterns=[clique.PATTERNS["frames"]])
         paths = []
         for collection in collections:
             padding = "#" * collection.padding

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -108,7 +108,7 @@ class AbstractSubmitDeadline(
             context.data["currentFile"],
             job_info.use_published
         )
-        self._append_job_output(
+        self.__append_job_output_paths(
             instance,
             self.job_info
         )
@@ -161,7 +161,7 @@ class AbstractSubmitDeadline(
         self.scene_path = file_path
         self.log.info("Using {} for render/export.".format(file_path))
 
-    def _append_job_output(self, instance, job_info):
+    def __append_job_output_paths(self, instance, job_info):
         """Set output part to Job info
 
         'expectedFiles' might be remapped after `_set_scene_path`

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -108,7 +108,7 @@ class AbstractSubmitDeadline(
             context.data["currentFile"],
             job_info.use_published
         )
-        self.job_info = self._set_job_output(
+        self.job_info = self._append_job_output(
             instance,
             self.job_info
         )
@@ -161,7 +161,7 @@ class AbstractSubmitDeadline(
         self.scene_path = file_path
         self.log.info("Using {} for render/export.".format(file_path))
 
-    def _set_job_output(self, instance, job_info):
+    def _append_job_output(self, instance, job_info):
         """Set output part to Job info
 
         'expectedFiles' might be remapped after `_set_scene_path`

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -108,7 +108,7 @@ class AbstractSubmitDeadline(
             context.data["currentFile"],
             job_info.use_published
         )
-        self.job_info = self._append_job_output(
+        self._append_job_output(
             instance,
             self.job_info
         )
@@ -170,8 +170,6 @@ class AbstractSubmitDeadline(
         first_file = next(iter_expected_files(instance.data["expectedFiles"]))
         job_info.OutputDirectory += os.path.dirname(first_file)
         job_info.OutputFilename += os.path.basename(first_file)
-
-        return job_info
 
     def process_submission(self):
         """Process data for submission.

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -109,7 +109,7 @@ class AbstractSubmitDeadline(
             context.data["currentFile"],
             job_info.use_published
         )
-        self.__append_job_output_paths(
+        self._append_job_output_paths(
             instance,
             self.job_info
         )
@@ -162,7 +162,7 @@ class AbstractSubmitDeadline(
         self.scene_path = file_path
         self.log.info("Using {} for render/export.".format(file_path))
 
-    def __append_job_output_paths(self, instance, job_info):
+    def _append_job_output_paths(self, instance, job_info):
         """Set output part to Job info
 
         'expectedFiles' might be remapped after `_set_scene_path`

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -165,7 +165,8 @@ class AbstractSubmitDeadline(
     def _append_job_output_paths(self, instance, job_info):
         """Set output part to Job info
 
-        'expectedFiles' might be remapped after `_set_scene_path`
+        Note: 'expectedFiles' might be remapped after `_set_scene_path`
+            due to remapping workfile to published workfile.
         Used in JobOutput > Explore output
         """
         collections, remainder = clique.assemble(

--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -108,6 +108,10 @@ class AbstractSubmitDeadline(
             context.data["currentFile"],
             job_info.use_published
         )
+        self.job_info = self._set_job_output(
+            instance,
+            self.job_info
+        )
         self.plugin_info = self.get_plugin_info()
 
         self.aux_files = self.get_aux_files()
@@ -157,6 +161,18 @@ class AbstractSubmitDeadline(
         self.scene_path = file_path
         self.log.info("Using {} for render/export.".format(file_path))
 
+    def _set_job_output(self, instance, job_info):
+        """Set output part to Job info
+
+        'expectedFiles' might be remapped after `_set_scene_path`
+        Used in JobOutput > Explore output
+        """
+        first_file = next(iter_expected_files(instance.data["expectedFiles"]))
+        job_info.OutputDirectory += os.path.dirname(first_file)
+        job_info.OutputFilename += os.path.basename(first_file)
+
+        return job_info
+
     def process_submission(self):
         """Process data for submission.
 
@@ -194,11 +210,6 @@ class AbstractSubmitDeadline(
             job_info.Pool = job_info.Pool
         if job_info.SecondaryPool != "none":
             job_info.SecondaryPool = job_info.SecondaryPool
-
-        exp = instance.data.get("expectedFiles")
-        for filepath in iter_expected_files(exp):
-            job_info.OutputDirectory += os.path.dirname(filepath)
-            job_info.OutputFilename += os.path.basename(filepath)
 
         # Adding file dependencies.
         if not is_in_tests() and job_info.use_asset_dependencies:

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -110,10 +110,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             if saver_instance is instance:
                 continue
 
-            exp = instance.data.get("expectedFiles")
-            for filepath in iter_expected_files(exp):
-                job_info.OutputDirectory += os.path.dirname(filepath)
-                job_info.OutputFilename += os.path.basename(filepath)
+            job_info = self._set_job_output(instance, job_info)
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -110,7 +110,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             if saver_instance is instance:
                 continue
 
-            job_info = self._set_job_output(instance, job_info)
+            job_info = self._append_job_output(instance, job_info)
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -1,9 +1,8 @@
-import os
 from dataclasses import dataclass, field, asdict
+
 import pyblish.api
 
 from ayon_core.pipeline.publish import AYONPyblishPluginMixin
-from ayon_core.pipeline.farm.tools import iter_expected_files
 from ayon_deadline import abstract_submit_deadline
 
 

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -110,7 +110,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             if saver_instance is instance:
                 continue
 
-            job_info = self._append_job_output(instance, job_info)
+            self._append_job_output(instance, job_info)
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -110,7 +110,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             if saver_instance is instance:
                 continue
 
-            self._append_job_output(instance, job_info)
+            self.__append_job_output_paths(instance, job_info)
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -110,7 +110,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             if saver_instance is instance:
                 continue
 
-            self.__append_job_output_paths(instance, job_info)
+            self._append_job_output_paths(instance, job_info)
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -73,6 +73,11 @@ class NukeSubmitDeadline(
         self._set_scene_path(
             context.data["currentFile"], job_info.use_published)
 
+        self._append_job_output_paths(
+            instance,
+            self.job_info
+        )
+
         self.plugin_info = self.get_plugin_info(
             scene_path=self.scene_path,
             render_path=render_path,


### PR DESCRIPTION
## Changelog Description
`jobInfo.OutputDir` now uses possibly remapped values of `expectedFiles`. 

`jobInfo.Output` now contains only single value, not one per `expectedFiles` file.


## Additional review information
It could happen that published workfile has different name than work workfile, `_set_scene_path` remaps `expectedFiles` to name of published workfile, `OutputDir` value was set before, eg. didn't respect that.

Not sure about Houdini and Max, there are some discrepancies I didn't want to touch. Could be modified in later PRs though.

## Testing notes:
1. publish in DCC of your choice to DL
2. check that `Job Output > Explore Job Output` in DL Monitor points to expected folder.
![image](https://github.com/user-attachments/assets/cce9a906-35d2-44d0-a48d-f4f01da6c2b0)

