### PR TITLE
Env variables: Set kitsu env variables

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
@@ -20,6 +20,11 @@ class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
         "FTRACK_API_USER",
         "FTRACK_SERVER",
 
+        # kitsu addon
+        "KITSU_SERVER",
+        "KITSU_LOGIN",
+        "KITSU_PWD",
+
         # Shotgrid / Flow addon
         "OPENPYPE_SG_USER",
 


### PR DESCRIPTION
## Changelog Description
Keep setting kitsu environment variables to support older kitsu addon versions.

## Additional review information
It was removed in https://github.com/ynput/ayon-deadline/pull/94 by accident.

## Testing notes:
1. Kitsu environment variables are passed into jobs.
