### PR TITLE
Added overrides for 2D DCC in Collect JobInfo

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -386,7 +386,14 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
-          "overrides": [],
+          "overrides": [
+            "department",
+            "chunk_size",
+            "group",
+            "priority",
+            "primary_pool",
+            "secondary_pool"
+          ],
           "chunk_size": 10,
           "department": "",
           "host_names": [


### PR DESCRIPTION
## Changelog Description
Without it nothing (`Priority`, `Pool` etc)  would show up in Publisher UI


## Testing notes:
1. redeploy addon
2. Check if you can see `JobInfo` properties in Nuke Publisher UI
