### PR TITLE
Publish UI populates pools from server settings

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -293,13 +293,13 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             EnumDef(
                 "primary_pool",
                 label="Primary pool",
-                default="none",
+                default=default_values.get("primary_pool"),
                 items=cls.pool_enum_values,
             ),
             EnumDef(
                 "secondary_pool",
                 label="Secondary pool",
-                default="none",
+                default=default_values.get("secondary_pool"),
                 items=cls.pool_enum_values,
             ),
             EnumDef(

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -293,13 +293,13 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             EnumDef(
                 "primary_pool",
                 label="Primary pool",
-                default=default_values.get("primary_pool"),
+                default=default_values.get("primary_pool", "none"),
                 items=cls.pool_enum_values,
             ),
             EnumDef(
                 "secondary_pool",
                 label="Secondary pool",
-                default=default_values.get("secondary_pool"),
+                default=default_values.get("secondary_pool", "none"),
                 items=cls.pool_enum_values,
             ),
             EnumDef(


### PR DESCRIPTION
## Changelog Description
This PR populates a publish instance's UI for `Primary Pool` and `Secondary Pool` from the `Collect JobInfo` profiles.
Addressed issue https://github.com/ynput/ayon-deadline/issues/85

## Testing notes:
1. define a JobInfo profile with values set in `Primary Pool` and `Secondary Pool`
2. expose these attributes
3. open a dcc and create a supported product type (render)
4. check the publish items UI for the exposed values and check whether they correspond with the server settings
