### PR TITLE
Fix assignment of job dependency

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -107,7 +107,7 @@ class NukeSubmitDeadline(
                 # frames_farm instance doesn't have render submission
                 if response_data.get("_id"):
                     self.job_info.BatchName = response_data["Props"]["Batch"]
-                    self.job_info.JobDependency0 = response_data["_id"]
+                    self.job_info.JobDependencies.append(response_data["_id"])
 
                 render_path = baking_script["bakeRenderPath"]
                 scene_path = baking_script["bakeScriptPath"]


### PR DESCRIPTION
## Changelog Description
Without it baking job wouldnt wait for rendering job.


## Testing notes:
1. render in Nuke with Deadline
2. check baking `Job properties > Dependencies`, there should be job with name from rendering job
<img width="367" alt="deadlinemonitor_VdKhZsr0Ik" src="https://github.com/user-attachments/assets/25fdb8b9-62c3-45fd-869a-5c27499ea182" />
