### PR TITLE
Added logging for location of metadata.json

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -432,6 +432,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             publish_job.update({"audio": audio_file})
 
         with open(metadata_path, "w") as f:
+            self.log.debug(f"Metadata json written to '{metadata_path}'")
             json.dump(publish_job, f, indent=4, sort_keys=True)
 
     def _get_publish_folder(self, anatomy, template_data,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -431,8 +431,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         if audio_file and os.path.isfile(audio_file):
             publish_job.update({"audio": audio_file})
 
+        self.log.debug(f"Metadata json written to '{metadata_path}'")
         with open(metadata_path, "w") as f:
-            self.log.debug(f"Metadata json written to '{metadata_path}'")
             json.dump(publish_job, f, indent=4, sort_keys=True)
 
     def _get_publish_folder(self, anatomy, template_data,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -431,7 +431,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         if audio_file and os.path.isfile(audio_file):
             publish_job.update({"audio": audio_file})
 
-        self.log.debug(f"Metadata json written to '{metadata_path}'")
+        self.log.debug(f"Writing metadata json to '{metadata_path}'")
         with open(metadata_path, "w") as f:
             json.dump(publish_job, f, indent=4, sort_keys=True)
 


### PR DESCRIPTION
## Changelog Description
Provides simple one logging line about where `metadata.json` for publishing job is stored. 


## Testing notes:
1. publish to Deadline
2. check log for `Submit Image Publishing job to Deadline`
![image](https://github.com/user-attachments/assets/b8833416-c11a-4236-b24f-cfc10c4c9f71)

