### PR TITLE
Do not update expected files if custom staging dir

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -176,7 +176,6 @@ class AbstractSubmitDeadline(
             due to remapping workfile to published workfile.
         Used in JobOutput > Explore output
         """
-        self.log.info(f"paths::{instance.data['expectedFiles']}")
         collections, remainder = clique.assemble(
             iter_expected_files(instance.data["expectedFiles"]),
             assume_padded_when_ambiguous=True,
@@ -187,7 +186,7 @@ class AbstractSubmitDeadline(
             path = collection.format(f"{{head}}{padding}{{tail}}")
             paths.append(path)
         paths.extend(remainder)
-        self.log.info(f"paths::{paths}")
+
         for path in paths:
             job_info.OutputDirectory += os.path.dirname(path)
             job_info.OutputFilename += os.path.basename(path)

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -71,7 +71,10 @@ class NukeSubmitDeadline(
         self.job_info = self.get_job_info(job_info=job_info)
 
         self._set_scene_path(
-            context.data["currentFile"], job_info.use_published)
+            context.data["currentFile"],
+            job_info.use_published,
+            instance.data.get("stagingDir_is_custom", False)
+        )
 
         self._append_job_output_paths(
             instance,


### PR DESCRIPTION
## Changelog Description
If published workfile is used for rendering, it shouldnt update path of explicit custom staging dir.

## Additional review information
Should be tested together with https://github.com/ynput/ayon-nuke/pull/58

## Testing notes:
1. set `ayon+settings://core/tools/publish/custom_staging_dir_profiles` for your DCC of choice to use custom staging dir
2. publish to DL
3. check that `OutputDirectory0` still points to that folder
![image](https://github.com/user-attachments/assets/8048cde7-0ec4-4174-af7f-d56e1e2f43dc)

