### PR TITLE
Ensure that SSL verification setting is respected by all plugins.

### DIFF
--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -92,10 +92,10 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
                 server_name, local_settings
             )
             server_url, auth, verify = con_info.url, con_info.auth, con_info.verify
-            pools = get_deadline_pools(server_url, auth, verify=verify)
-            groups = get_deadline_groups(server_url, auth, verify=verify)
-            limit_groups = get_deadline_limit_groups(server_url, auth, verify=verify)
-            machines = get_deadline_workers(server_url, auth, verify=verify)
+            pools = get_deadline_pools(server_url, auth, verify)
+            groups = get_deadline_groups(server_url, auth, verify)
+            limit_groups = get_deadline_limit_groups(server_url, auth, verify)
+            machines = get_deadline_workers(server_url, auth, verify)
             server_info = DeadlineServerInfo(
                 pools=pools,
                 limit_groups=limit_groups,

--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -91,11 +91,11 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
             con_info = self.get_deadline_server_connection_info(
                 server_name, local_settings
             )
-            server_url, auth = con_info.url, con_info.auth
-            pools = get_deadline_pools(server_url, auth)
-            groups = get_deadline_groups(server_url, auth)
-            limit_groups = get_deadline_limit_groups(server_url, auth)
-            machines = get_deadline_workers(server_url, auth)
+            server_url, auth, verify = con_info.url, con_info.auth, con_info.verify
+            pools = get_deadline_pools(server_url, auth, verify=verify)
+            groups = get_deadline_groups(server_url, auth, verify=verify)
+            limit_groups = get_deadline_limit_groups(server_url, auth, verify=verify)
+            machines = get_deadline_workers(server_url, auth, verify=verify)
             server_info = DeadlineServerInfo(
                 pools=pools,
                 limit_groups=limit_groups,

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -82,7 +82,8 @@ class JobType(str, Enum):
 def get_deadline_pools(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None
+    log: Optional[Logger] = None,
+    verify: Optional[bool] = None,
 ) -> List[str]:
     """Get pools from Deadline API.
 
@@ -91,7 +92,8 @@ def get_deadline_pools(
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
         log (Optional[Logger]): Logger to log errors to, if provided.
-
+        verify(Optional[bool]): Whether to verify the TLS certificate
+            of the Deadline Web Service.
     Returns:
         List[str]: Limit Groups.
 
@@ -100,13 +102,14 @@ def get_deadline_pools(
 
     """
     endpoint = f"{webservice_url}/api/pools?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, "pools")
+    return _get_deadline_info(endpoint, auth, log, verify, "pools")
 
 
 def get_deadline_groups(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None
+    log: Optional[Logger] = None,
+    verify: Optional[bool] = None,
 ) -> List[str]:
     """Get Groups from Deadline API.
 
@@ -115,7 +118,8 @@ def get_deadline_groups(
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
         log (Optional[Logger]): Logger to log errors to, if provided.
-
+        verify(Optional[bool]): Whether to verify the TLS certificate
+            of the Deadline Web Service.
     Returns:
         List[str]: Limit Groups.
 
@@ -124,13 +128,14 @@ def get_deadline_groups(
 
     """
     endpoint = f"{webservice_url}/api/groups"
-    return _get_deadline_info(endpoint, auth, log, "groups")
+    return _get_deadline_info(endpoint, auth, log, verify, "groups")
 
 
 def get_deadline_limit_groups(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None
+    log: Optional[Logger] = None,
+    verify: Optional[bool] = None,
 ) -> List[str]:
     """Get Limit Groups from Deadline API.
 
@@ -139,7 +144,8 @@ def get_deadline_limit_groups(
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
         log (Optional[Logger]): Logger to log errors to, if provided.
-
+        verify(Optional[bool]): Whether to verify the TLS certificate
+            of the Deadline Web Service.
     Returns:
         List[str]: Limit Groups.
 
@@ -148,12 +154,13 @@ def get_deadline_limit_groups(
 
     """
     endpoint = f"{webservice_url}/api/limitgroups?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, "limitgroups")
+    return _get_deadline_info(endpoint, auth, log, verify, "limitgroups")
 
 def get_deadline_workers(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None
+    log: Optional[Logger] = None,
+    verify: Optional[bool] = None,
 ) -> List[str]:
     """Get Workers (eg.machine names) from Deadline API.
 
@@ -162,7 +169,8 @@ def get_deadline_workers(
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
         log (Optional[Logger]): Logger to log errors to, if provided.
-
+        verify(Optional[bool]): Whether to verify the TLS certificate
+            of the Deadline Web Service.
     Returns:
         List[str]: Limit Groups.
 
@@ -171,14 +179,15 @@ def get_deadline_workers(
 
     """
     endpoint = f"{webservice_url}/api/slaves?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, "workers")
+    return _get_deadline_info(endpoint, auth, log, verify, "workers")
 
 
 def _get_deadline_info(
-    endpoint,
-    auth,
-    log,
-    item_type
+    endpoint: str,
+    auth: Optional[Tuple[str, str]],
+    log: Optional[Logger],
+    verify: Optional[bool],
+    item_type: str,
 ):
     from .abstract_submit_deadline import requests_get
 
@@ -187,6 +196,8 @@ def _get_deadline_info(
 
     try:
         kwargs = {}
+        if verify is not None:
+            kwargs["verify"] = verify
         if auth:
             kwargs["auth"] = auth
         response = requests_get(endpoint, **kwargs)

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -82,8 +82,8 @@ class JobType(str, Enum):
 def get_deadline_pools(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None,
     verify: Optional[bool] = None,
+    log: Optional[Logger] = None,
 ) -> List[str]:
     """Get pools from Deadline API.
 
@@ -91,9 +91,9 @@ def get_deadline_pools(
         webservice_url (str): Server url.
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
-        log (Optional[Logger]): Logger to log errors to, if provided.
         verify(Optional[bool]): Whether to verify the TLS certificate
             of the Deadline Web Service.
+        log (Optional[Logger]): Logger to log errors to, if provided.
     Returns:
         List[str]: Limit Groups.
 
@@ -102,14 +102,14 @@ def get_deadline_pools(
 
     """
     endpoint = f"{webservice_url}/api/pools?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, verify, "pools")
+    return _get_deadline_info(endpoint, auth, verify, "pools", log)
 
 
 def get_deadline_groups(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None,
     verify: Optional[bool] = None,
+    log: Optional[Logger] = None,
 ) -> List[str]:
     """Get Groups from Deadline API.
 
@@ -117,9 +117,9 @@ def get_deadline_groups(
         webservice_url (str): Server url.
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
-        log (Optional[Logger]): Logger to log errors to, if provided.
         verify(Optional[bool]): Whether to verify the TLS certificate
             of the Deadline Web Service.
+        log (Optional[Logger]): Logger to log errors to, if provided.
     Returns:
         List[str]: Limit Groups.
 
@@ -128,14 +128,14 @@ def get_deadline_groups(
 
     """
     endpoint = f"{webservice_url}/api/groups"
-    return _get_deadline_info(endpoint, auth, log, verify, "groups")
+    return _get_deadline_info(endpoint, auth, verify, "groups", log)
 
 
 def get_deadline_limit_groups(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None,
     verify: Optional[bool] = None,
+    log: Optional[Logger] = None,
 ) -> List[str]:
     """Get Limit Groups from Deadline API.
 
@@ -143,9 +143,9 @@ def get_deadline_limit_groups(
         webservice_url (str): Server url.
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
-        log (Optional[Logger]): Logger to log errors to, if provided.
         verify(Optional[bool]): Whether to verify the TLS certificate
             of the Deadline Web Service.
+        log (Optional[Logger]): Logger to log errors to, if provided.
     Returns:
         List[str]: Limit Groups.
 
@@ -154,13 +154,13 @@ def get_deadline_limit_groups(
 
     """
     endpoint = f"{webservice_url}/api/limitgroups?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, verify, "limitgroups")
+    return _get_deadline_info(endpoint, auth, verify, "limitgroups", log)
 
 def get_deadline_workers(
     webservice_url: str,
     auth: Optional[Tuple[str, str]] = None,
-    log: Optional[Logger] = None,
     verify: Optional[bool] = None,
+    log: Optional[Logger] = None,
 ) -> List[str]:
     """Get Workers (eg.machine names) from Deadline API.
 
@@ -168,9 +168,9 @@ def get_deadline_workers(
         webservice_url (str): Server url.
         auth (Optional[Tuple[str, str]]): Tuple containing username,
             password
-        log (Optional[Logger]): Logger to log errors to, if provided.
         verify(Optional[bool]): Whether to verify the TLS certificate
             of the Deadline Web Service.
+        log (Optional[Logger]): Logger to log errors to, if provided.
     Returns:
         List[str]: Limit Groups.
 
@@ -179,15 +179,15 @@ def get_deadline_workers(
 
     """
     endpoint = f"{webservice_url}/api/slaves?NamesOnly=true"
-    return _get_deadline_info(endpoint, auth, log, verify, "workers")
+    return _get_deadline_info(endpoint, auth, verify, "workers", log)
 
 
 def _get_deadline_info(
     endpoint: str,
     auth: Optional[Tuple[str, str]],
-    log: Optional[Logger],
     verify: Optional[bool],
     item_type: str,
+    log: Optional[Logger],
 ):
     from .abstract_submit_deadline import requests_get
 

--- a/client/ayon_deadline/plugins/publish/global/validate_deadline_connection.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_deadline_connection.py
@@ -24,7 +24,10 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
         deadline_url = instance.data["deadline"]["url"]
         assert deadline_url, "Requires Deadline Webservice URL"
 
-        kwargs = {}
+        kwargs = {
+            "verify": instance.data["deadline"]["verify"]
+        }
+
         if instance.data["deadline"]["require_authentication"]:
             auth = instance.data["deadline"]["auth"]
             kwargs["auth"] = auth

--- a/client/ayon_deadline/plugins/publish/global/validate_deadline_pools.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_deadline_pools.py
@@ -38,7 +38,8 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
         pools = self.get_pools(
             deadline_addon,
             deadline_url,
-            instance.data["deadline"].get("auth")
+            instance.data["deadline"].get("auth"),
+            verify=instance.data["deadline"]["verify"]
         )
 
         invalid_pools = {}
@@ -63,14 +64,14 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
                 formatting_data={"pools_str": ", ".join(pools)}
             )
 
-    def get_pools(self, deadline_addon, deadline_url, auth):
+    def get_pools(self, deadline_addon, deadline_url, auth, verify):
         if deadline_url not in self.pools_by_url:
             self.log.debug(
                 "Querying available pools for Deadline url: {}".format(
                     deadline_url)
             )
             pools = get_deadline_pools(
-                deadline_url, auth=auth, log=self.log
+                deadline_url, auth=auth, log=self.log, verify=verify
             )
             # some DL return "none" as a pool name
             if "none" not in pools:

--- a/client/ayon_deadline/plugins/publish/global/validate_deadline_pools.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_deadline_pools.py
@@ -39,7 +39,7 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
             deadline_addon,
             deadline_url,
             instance.data["deadline"].get("auth"),
-            verify=instance.data["deadline"]["verify"]
+            instance.data["deadline"]["verify"]
         )
 
         invalid_pools = {}


### PR DESCRIPTION
We currently have the `Don't verify SSL` option in the AYON Deadline plugin enabled for our studio, but found when testing with Maya that the plugins validating the Deadline connection and pools would not pass the `verify=False` flag down to requests and so were borking out with SSL verification errors.

This PR (somewhat clumsily - but it was the cleanest way I could without any `lib.py` refactor) passes that flag down from settings into each of the calls made by the authentication plugins. 