### PR TITLE
AE Submit job: Fix method signature

### DIFF
--- a/client/ayon_deadline/plugins/publish/aftereffects/submit_aftereffects_deadline.py
+++ b/client/ayon_deadline/plugins/publish/aftereffects/submit_aftereffects_deadline.py
@@ -75,7 +75,7 @@ class AfterEffectsSubmitDeadline(
 
         return asdict(deadline_plugin_info)
 
-    def from_published_scene(self):
+    def from_published_scene(self, replace_in_path=True):
         """ Do not overwrite expected files.
 
             Use published is set to True, so rendering will be triggered


### PR DESCRIPTION
## Changelog Description
New implementation in abstract_submit_deadline forces `replace_in_path` argument.

## Additional info
Found by automatic tests.

## Testing notes:
1. publish with AE in DL
2. shouldnt fail
