### PR TITLE
Chore: Use 'AYON_USE_STAGING'

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py
@@ -30,6 +30,10 @@ class CollectDeadlineJobEnvVars(pyblish.api.ContextPlugin):
 
         # Not sure how this is usefull for farm, scared to remove
         "PYBLISHPLUGINPATH",
+
+        # NOTE still required by GlobalPreLoadJob.py, but might not be set by
+        #   ayon-core anymore
+        "AYON_DEFAULT_SETTINGS_VARIANT",
     ]
 
     def process(self, context):

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -202,6 +202,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         # TODO remove when AYON launcher respects environment variable
         #   'AYON_DEFAULT_SETTINGS_VARIANT'
         settings_variant = os.environ["AYON_DEFAULT_SETTINGS_VARIANT"]
+        # NOTE is removed from ayon-core, but still required by
+        #   GlobalPreLoadJob.py
+        environment["AYON_DEFAULT_SETTINGS_VARIANT"] = settings_variant
         if settings_variant == "staging":
             args.append("--use-staging")
         elif settings_variant != "production":

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -202,9 +202,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         # TODO remove settings variant handling when not needed anymore
         #   which should be when package.py defines 'core>1.1.1' .
         settings_variant = os.environ["AYON_DEFAULT_SETTINGS_VARIANT"]
-        # NOTE still required by GlobalPreLoadJob.py, but might not be set by
-        #   ayon-core anymore
-        environment["AYON_DEFAULT_SETTINGS_VARIANT"] = settings_variant
         if settings_variant == "staging":
             args.append("--use-staging")
         elif settings_variant != "production":

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -199,11 +199,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "--targets", "deadline",
             "--targets", "farm",
         ]
-        # TODO remove when AYON launcher respects environment variable
-        #   'AYON_DEFAULT_SETTINGS_VARIANT'
+        # TODO remove settings variant handling when not needed anymore
+        #   which should be when package.py defines 'core>1.1.1' .
         settings_variant = os.environ["AYON_DEFAULT_SETTINGS_VARIANT"]
-        # NOTE is removed from ayon-core, but still required by
-        #   GlobalPreLoadJob.py
+        # NOTE still required by GlobalPreLoadJob.py, but might not be set by
+        #   ayon-core anymore
         environment["AYON_DEFAULT_SETTINGS_VARIANT"] = settings_variant
         if settings_variant == "staging":
             args.append("--use-staging")

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -13,7 +13,7 @@ from Deadline.Scripting import (
     FileUtils,
     DirectoryUtils,
 )
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -583,9 +583,11 @@ def inject_ayon_environment(deadlinePlugin):
             "AYON_BUNDLE_NAME": ayon_bundle_name,
         }
 
-        automatic_tests = job.GetJobEnvironmentKeyValue("AYON_IN_TESTS")
-        if automatic_tests:
-            environment["AYON_IN_TESTS"] = automatic_tests
+        for key in ("AYON_USE_STAGING", "AYON_IN_TESTS"):
+            value = job.GetJobEnvironmentKeyValue(key)
+            if value:
+                environment[key] = value
+
         for env, val in environment.items():
             # Add the env var for the Render Plugin that is about to render
             deadlinePlugin.SetEnvironmentVariable(env, val)

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -558,8 +558,12 @@ def inject_ayon_environment(deadlinePlugin):
         ]
 
         # staging requires passing argument
-        # TODO could be switched to env var after https://github.com/ynput/ayon-launcher/issues/123
-        settings_variant = job.GetJobEnvironmentKeyValue("AYON_DEFAULT_SETTINGS_VARIANT")  # noqa
+        # TODO could be removed when PR in ayon-core starts to fill
+        #  'AYON_USE_STAGING' (https://github.com/ynput/ayon-core/pull/1130)
+        #  - add requirement for "core>=1.1.1" to 'package.py' when removed
+        settings_variant = job.GetJobEnvironmentKeyValue(
+            "AYON_DEFAULT_SETTINGS_VARIANT"
+        )
         if settings_variant == "staging":
             args.append("--use-staging")
 


### PR DESCRIPTION
## Changelog Description
GlobalPreLoadJob.py does respect `AYON_USE_STAGING` environment variable as replacement for `AYON_DEFAULT_SETTINGS_VARIANT`.

## Additional review information
Environment variable `AYON_DEFAULT_SETTINGS_VARIANT` is still used for backwards compatibility. It is also explicitly set by deadline addon now, so ayon-core does not have to set it up for future deprecation.

This change is preparation for future cleanup that can't happen now to keep backwards compatibility.

### Logic leading to this change
We need to know if AYON process should happen as production, staging or dev. Dev is defined just by bundle name, production is also defined only by bundle name, and staging needs bundle name and `AYON_USE_STAGING`, so we don't need `AYON_DEFAULT_SETTINGS_VARIANT` at all if we have `AYON_BUNDLE_NAME` and `AYON_USE_STAGING` available.

### Future plans
We need to support backwards compatibility, so changing GlobalPreLoadJob might be dangerous now, as we probably should support bigger range of addon versions.
But when we bump requirement of ayon-core to `>1.1.1` we don't have to set up `AYON_DEFAULT_SETTINGS_VARIANT` anymore, as staging will be defined by `AYON_USE_STAGING`.

## Testing notes:
1. Deadline `GlobalPreLoadJob.py` must be copied to deadline repository.
2. For now nothing should change as both core and deadline are still setting `AYON_DEFAULT_SETTINGS_VARIANT`.

## To validate new logic
1. Use https://github.com/ynput/ayon-core/pull/1130 .
2. Add custom plugin that happens after collection (e.g. during validation) that will remove `AYON_DEFAULT_SETTINGS_VARIANT` from `context.data[FARM_JOB_ENV_DATA_KEY]`.
3. With these changes it should be possible to submit production, staging and dev jobs.

Resolves https://github.com/ynput/ayon-deadline/issues/129