### PR TITLE
Fix logging correct default `ayon_server_url` in the logged message

### DIFF
--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.param
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.param
@@ -9,30 +9,30 @@ Description=Not configurable
 
 [AyonExecutable]
 Type=multilinemultifilename
-Label=Ayon Executable
-Category=Ayon Executables
+Label=AYON Executable
+Category=AYON Executables
 CategoryOrder=1
 Index=0
 Default=
-Description=The path to the Ayon executable. Enter alternative paths on separate lines.
+Description=The path to the AYON executable. Enter alternative paths on separate lines.
 
 [AyonServerUrl]
 Type=string
-Label=Ayon Server Url
-Category=Ayon Credentials
+Label=AYON Server Url
+Category=AYON Credentials
 CategoryOrder=2
 Index=0
 Default=
-Description=Url to Ayon server
+Description=Url to AYON server
 
 [AyonApiKey]
 Type=password
-Label=Ayon API key
-Category=Ayon Credentials
+Label=AYON API key
+Category=AYON Credentials
 CategoryOrder=2
 Index=0
 Default=
-Description=API key for service account on Ayon Server
+Description=API key for service account on AYON Server
 
 [AyonAdditionalServerUrls]
 Type=multilinestring

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -30,7 +30,7 @@ def CleanupDeadlinePlugin(deadlinePlugin):
 
 class AyonDeadlinePlugin(DeadlinePlugin):
     """
-        Standalone plugin for publishing from Ayon
+        Standalone plugin for publishing from AYON
 
         Calls Ayonexecutable 'ayon_console' from first correctly found
         file based on plugin configuration. Uses 'publish' command and passes
@@ -68,9 +68,9 @@ class AyonDeadlinePlugin(DeadlinePlugin):
     def RenderExecutable(self):
         job = self.GetJob()
 
-        # set required env vars for Ayon
+        # set required env vars for AYON
         # cannot be in InitializeProcess as it is too soon
-        config = RepositoryUtils.GetPluginConfig("Ayon")
+        config = RepositoryUtils.GetPluginConfig("Ayon")  # plugin name stays
         ayon_server_url = (
                 job.GetJobEnvironmentKeyValue("AYON_SERVER_URL") or
                 config.GetConfigEntryWithDefault("AyonServerUrl", "")
@@ -104,7 +104,7 @@ class AyonDeadlinePlugin(DeadlinePlugin):
 
         if exe == "":
             self.FailRender(
-                "Ayon executable was not found in the semicolon separated "
+                "AYON executable was not found in the semicolon separated "
                 "list: \"{}\". The path to the render executable can be "
                 "configured from the Plugin Configuration in the Deadline "
                 "Monitor.".format(exe_list)

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -13,7 +13,7 @@ from Deadline.Scripting import (
     FileUtils,
     DirectoryUtils,
 )
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -505,7 +505,7 @@ def inject_ayon_environment(deadlinePlugin):
                     "in AYON Deadline plugin configuration,"
                     " `Additional AYON Servers` section."
                     " Use Deadline monitor to modify the values."
-                    "Falling back to `Ayon API key` set in `Ayon Credentials`"
+                    "Falling back to `AYON API key` set in `AYON Credentials`"
                     " section of AYON plugin configuration."
                 )
             ayon_server_url = job_ayon_server_url

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -500,12 +500,12 @@ def inject_ayon_environment(deadlinePlugin):
                 ayon_api_key = api_key
             else:
                 print(
-                    "AYON Server URL submitted with job"
-                    f" '{job_ayon_server_url}' is not the Deadline AYON"
-                    f" Plug-in default server URL '{ayon_server_url}' but"
-                    " has no API key defined in Additional Server URLs."
-                    " Falling back to default API key configured in"
-                    " Deadline repository for the AYON plug-in."
+                    "AYON Server URL submitted with job "
+                    f"'{job_ayon_server_url}' has no API key defined "
+                    "in `Additional AYON Servers` in AYON Deadline plugin " 
+                    "configuration in Deadline repository. "
+                    "Falling back to `Ayon API key` set in `Ayon Credentials`"
+                    " section of AYON plugin configuration."
                 )
             ayon_server_url = job_ayon_server_url
 

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -502,7 +502,7 @@ def inject_ayon_environment(deadlinePlugin):
                 print(
                     "AYON Server URL submitted with job "
                     f"'{job_ayon_server_url}' has no API key defined "
-                    "in AYON Deadline plugin configuration," 
+                    "in AYON Deadline plugin configuration,"
                     " `Additional AYON Servers` section."
                     " Use Deadline monitor to modify the values."
                     "Falling back to `Ayon API key` set in `Ayon Credentials`"

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -464,13 +464,13 @@ def inject_ayon_environment(deadlinePlugin):
 
         if not exe:
             raise RuntimeError((
-               "Ayon executable was not found in the semicolon "
+               "AYON executable was not found in the semicolon "
                "separated list \"{}\"."
                "The path to the render executable can be configured"
                " from the Plugin Configuration in the Deadline Monitor."
             ).format(exe_list))
 
-        print("--- Ayon executable: {}".format(exe))
+        print("--- AYON executable: {}".format(exe))
 
         ayon_bundle_name = job.GetJobEnvironmentKeyValue("AYON_BUNDLE_NAME")
         if not ayon_bundle_name:
@@ -512,7 +512,7 @@ def inject_ayon_environment(deadlinePlugin):
         if not all([ayon_server_url, ayon_api_key]):
             raise RuntimeError((
                 "Missing required values for server url and api key. "
-                "Please fill in Ayon Deadline plugin or provide by "
+                "Please fill in AYON Deadline plugin or provide by "
                 "AYON_SERVER_URL and AYON_API_KEY"
             ))
 
@@ -660,7 +660,7 @@ def get_ayon_executable():
     if not exe_list:
         raise RuntimeError(
             "Path to AYON executable not configured."
-            "Please set it in Ayon Deadline Plugin."
+            "Please set it in AYON Deadline Plugin."
         )
 
     # clean '\ ' for MacOS pasting

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -494,7 +494,6 @@ def inject_ayon_environment(deadlinePlugin):
         # Deadline Repository AYON Plug-in settings, in the format of
         # `SERVER:PORT@APIKEY` per line.
         elif job_ayon_server_url and job_ayon_server_url != ayon_server_url:
-            ayon_server_url = job_ayon_server_url
             api_key = get_ayon_api_key_from_additional_servers(
                 config, job_ayon_server_url)
             if api_key:
@@ -508,6 +507,7 @@ def inject_ayon_environment(deadlinePlugin):
                     " Falling back to default API key configured in"
                     " Deadline repository for the AYON plug-in."
                 )
+            ayon_server_url = job_ayon_server_url
 
         if not all([ayon_server_url, ayon_api_key]):
             raise RuntimeError((

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -502,8 +502,9 @@ def inject_ayon_environment(deadlinePlugin):
                 print(
                     "AYON Server URL submitted with job "
                     f"'{job_ayon_server_url}' has no API key defined "
-                    "in `Additional AYON Servers` in AYON Deadline plugin " 
-                    "configuration in Deadline repository. "
+                    "in AYON Deadline plugin configuration," 
+                    " `Additional AYON Servers` section."
+                    " Use Deadline monitor to modify the values."
                     "Falling back to `Ayon API key` set in `Ayon Credentials`"
                     " section of AYON plugin configuration."
                 )


### PR DESCRIPTION
## Changelog Description

Do not override `ayon_server_url` variable before logging it.

If using a custom job url the logs should now not report the job url twice, but actually would report the 'default ayon url' to compare with. That fixes the log, and greatly clarifies the actual message too.

## Additional review information

Requires updating the `GlobalJobPreLoad.py` on your Deadline repo.

 #42 implemented the feature originally.

## Testing notes:

1. If using a custom job url the logs should now not report the job url twice, but actually would report the 'default ayon url' to compare with. That fixes the log, and greatly clarifies the actual message too.
