### PR TITLE
Fix: remove trailing slash in host url

### DIFF
--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -248,7 +248,7 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         auth = self._get_server_user_auth(dl_server_info, local_settings)
         return DeadlineConnectionInfo(
             server_name,
-            dl_server_info["value"],
+            dl_server_info["value"].rstrip("/"),
             auth,
             not dl_server_info["not_verify_ssl"],
         )


### PR DESCRIPTION
## Changelog Description
Removes trailing issue in Deadline server url which caused issue in retrieval of `api/jobs` in `Submit Image Publishing job to Deadline`

## Additional review information


## Testing notes:
1. set Deadline server url with trailing slash
![image](https://github.com/user-attachments/assets/948c58c9-5fca-4c2d-95b8-fdb9f7b1e69a)
2. publish via DL