### PR TITLE
Added possibility to control state of Publish job in Settings and Publisher UI

### DIFF
--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -627,6 +627,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
     """Contains additional AYON variables from Settings for internal logic."""
 
     # AYON custom fields used for Settings
+    publish_job_suspended: Optional[bool] = field(default=False)
     use_published: Optional[bool] = field(default=None)
     use_asset_dependencies: Optional[bool] = field(default=None)
     use_workfile_dependency: Optional[bool] = field(default=None)
@@ -646,6 +647,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "SecondaryPool": cls._sanitize(data["secondary_pool"]),
 
             # fields needed for logic, values unavailable during collection
+            "publish_job_suspended": data["publish_job_suspended"],
             "use_published": data["use_published"],
             "use_asset_dependencies": data["use_asset_dependencies"],
             "use_workfile_dependency": data["use_workfile_dependency"],
@@ -669,6 +671,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
         self, key: str, value: Any, output: Dict[str, Any]
     ):
         if key not in (
+            "publish_job_suspended",
             "use_published",
             "use_asset_dependencies",
             "use_workfile_dependency",

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -627,7 +627,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
     """Contains additional AYON variables from Settings for internal logic."""
 
     # AYON custom fields used for Settings
-    publish_job_suspended: Optional[bool] = field(default=False)
+    suspend_publish_job: Optional[bool] = field(default=False)
     use_published: Optional[bool] = field(default=None)
     use_asset_dependencies: Optional[bool] = field(default=None)
     use_workfile_dependency: Optional[bool] = field(default=None)
@@ -647,7 +647,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "SecondaryPool": cls._sanitize(data["secondary_pool"]),
 
             # fields needed for logic, values unavailable during collection
-            "publish_job_suspended": data["publish_job_suspended"],
+            "suspend_publish_job": data["suspend_publish_job"],
             "use_published": data["use_published"],
             "use_asset_dependencies": data["use_asset_dependencies"],
             "use_workfile_dependency": data["use_workfile_dependency"],
@@ -671,7 +671,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
         self, key: str, value: Any, output: Dict[str, Any]
     ):
         if key not in (
-            "publish_job_suspended",
+            "suspend_publish_job",
             "use_published",
             "use_asset_dependencies",
             "use_workfile_dependency",

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -627,7 +627,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
     """Contains additional AYON variables from Settings for internal logic."""
 
     # AYON custom fields used for Settings
-    suspend_publish_job: Optional[bool] = field(default=False)
+    publish_job_state : Optional[str] = field(default=None)
     use_published: Optional[bool] = field(default=None)
     use_asset_dependencies: Optional[bool] = field(default=None)
     use_workfile_dependency: Optional[bool] = field(default=None)
@@ -647,7 +647,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "SecondaryPool": cls._sanitize(data["secondary_pool"]),
 
             # fields needed for logic, values unavailable during collection
-            "suspend_publish_job": data["suspend_publish_job"],
+            "publish_job_state": data["publish_job_state"],
             "use_published": data["use_published"],
             "use_asset_dependencies": data["use_asset_dependencies"],
             "use_workfile_dependency": data["use_workfile_dependency"],
@@ -671,7 +671,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
         self, key: str, value: Any, output: Dict[str, Any]
     ):
         if key not in (
-            "suspend_publish_job",
+            "publish_job_state",
             "use_published",
             "use_asset_dependencies",
             "use_workfile_dependency",

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -321,10 +321,14 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 tooltip="Delay job by specified timecode. Format: dd:hh:mm:ss",
                 placeholder="00:00:00:00"
             ),
-            BoolDef(
-                "suspend_publish_job",
-                label="Suspend Publish Job",
-                default=default_values.get("suspend_publish_job")
+            EnumDef(
+                "publish_job_state",
+                label="Publish Job State",
+                default=default_values.get("publish_job_state"),
+                items=[
+                    {"value": "active", "label": "Active"},
+                    {"value": "suspended", "label": "Suspended"}
+                ]
             )
         ]
 

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -322,9 +322,9 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 placeholder="00:00:00:00"
             ),
             BoolDef(
-                "publish_job_suspended",
-                label="Publish Job Suspended",
-                default=default_values.get("publish_job_suspended")
+                "suspend_publish_job",
+                label="Suspend Publish Job",
+                default=default_values.get("suspend_publish_job")
             )
         ]
 

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -320,6 +320,11 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 default=default_values.get("job_delay"),
                 tooltip="Delay job by specified timecode. Format: dd:hh:mm:ss",
                 placeholder="00:00:00:00"
+            ),
+            BoolDef(
+                "publish_job_suspended",
+                label="Publish Job Suspended",
+                default=default_values.get("publish_job_suspended")
             )
         ]
 

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -182,13 +182,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             or instance.data.get("priority", 50)
         )
 
-        job_info = instance.data["deadline"]["job_info"]
-        initial_status = (
-            "Suspended"
-            if job_info.suspend_publish_job
-            else "Active"
-        )
-
         batch_name = self._get_batch_name(instance, render_job)
         username = self._get_username(instance, render_job)
         dependency_ids = self._get_dependency_ids(instance, render_job)
@@ -215,12 +208,13 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
+        job_info = instance.data["deadline"]["job_info"]
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=batch_name,
             Department=self.deadline_department,
             Priority=priority,
-            InitialStatus=initial_status,
+            InitialStatus=job_info.publish_job_state,
             Group=self.deadline_group,
             Pool=self.deadline_pool or None,
             JobDependencies=dependency_ids,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -11,7 +11,6 @@ import ayon_api
 import pyblish.api
 
 from ayon_core.pipeline import publish
-from ayon_core.lib import EnumDef
 from ayon_core.pipeline.version_start import get_versioning_start
 from ayon_core.pipeline.farm.pyblish_functions import (
     create_skeleton_instance,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -182,8 +182,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             or instance.data.get("priority", 50)
         )
 
-        instance_settings = self.get_attr_values_from_data(instance.data)
-        initial_status = instance_settings.get("publishJobState", "Active")
+        job_info = instance.data["deadline"]["job_info"]
+        initial_status = (
+            "Suspended"
+            if job_info.publish_job_suspended
+            else "Active"
+        )
 
         batch_name = self._get_batch_name(instance, render_job)
         username = self._get_username(instance, render_job)

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -185,7 +185,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         job_info = instance.data["deadline"]["job_info"]
         initial_status = (
             "Suspended"
-            if job_info.publish_job_suspended
+            if job_info.suspend_publish_job
             else "Active"
         )
 

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -77,9 +77,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             in the output filename to be picked up for image sequence
             publishing.
 
-        - publishJobState (str, Optional): "Active" or "Suspended"
-            This defaults to "Suspended"
-
         - expectedFiles (list or dict): explained below
 
     """
@@ -512,12 +509,3 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "publish", template_name, "directory"
         )
         return render_dir_template.format_strict(template_data)
-
-    @classmethod
-    def get_attribute_defs(cls):
-        return [
-            EnumDef("publishJobState",
-                    label="Publish Job State",
-                    items=["Active", "Suspended"],
-                    default="Active")
-        ]

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -116,13 +116,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
 
         priority = self.deadline_priority or instance.data.get("priority", 50)
 
-        job_info = instance.data["deadline"]["job_info"]
-        initial_status = (
-            "Suspended"
-            if job_info.suspend_publish_job
-            else "Active"
-        )
-
         args = [
             "--headless",
             'publish',
@@ -142,12 +135,13 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
+        job_info = instance.data["deadline"]["job_info"]
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=job["Props"]["Batch"],
             Department=self.deadline_department,
             Priority=priority,
-            InitialStatus=initial_status,
+            InitialStatus=job_info.publish_job_state,
             Group=self.deadline_group,
             Pool=self.deadline_pool or None,
             JobDependencies=dependency_ids,

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -9,7 +9,6 @@ import ayon_api
 import pyblish.api
 
 from ayon_core.pipeline import publish
-from ayon_core.lib import EnumDef
 from ayon_core.pipeline.version_start import get_versioning_start
 from ayon_core.pipeline.farm.pyblish_functions import (
     create_skeleton_instance_cache,

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -116,8 +116,12 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
 
         priority = self.deadline_priority or instance.data.get("priority", 50)
 
-        instance_settings = self.get_attr_values_from_data(instance.data)
-        initial_status = instance_settings.get("publishJobState", "Active")
+        job_info = instance.data["deadline"]["job_info"]
+        initial_status = (
+            "Suspended"
+            if job_info.publish_job_suspended
+            else "Active"
+        )
 
         args = [
             "--headless",
@@ -395,12 +399,3 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             "publish", template_name, "directory"
         )
         return render_dir_template.format_strict(template_data)
-
-    @classmethod
-    def get_attribute_defs(cls):
-        return [
-            EnumDef("publishJobState",
-                    label="Publish Job State",
-                    items=["Active", "Suspended"],
-                    default="Active")
-        ]

--- a/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_publish_cache_job.py
@@ -119,7 +119,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         job_info = instance.data["deadline"]["job_info"]
         initial_status = (
             "Suspended"
-            if job_info.publish_job_suspended
+            if job_info.suspend_publish_job
             else "Active"
         )
 

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -100,7 +100,6 @@ class NukeSubmitDeadline(
             render_path = instance.data["path"]
             instance.data["outputDir"] = os.path.dirname(
                 render_path).replace("\\", "/")
-            instance.data["publishJobState"] = "Suspended"
 
         if instance.data.get("bakingNukeScripts"):
             for baking_script in instance.data["bakingNukeScripts"]:

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -40,7 +40,7 @@ def extract_jobinfo_overrides_enum():
         {"value": "secondary_pool", "label": "Secondary pool"},
         {"value": "machine_list", "label": "Machine List"},
         {"value": "machine_list_deny", "label": "Machine List is a Deny"},
-        {"value": "publish_job_state ", "label": "Publish Job State"},
+        {"value": "publish_job_state", "label": "Publish Job State"},
     ]
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -40,7 +40,7 @@ def extract_jobinfo_overrides_enum():
         {"value": "secondary_pool", "label": "Secondary pool"},
         {"value": "machine_list", "label": "Machine List"},
         {"value": "machine_list_deny", "label": "Machine List is a Deny"},
-        {"value": "publish_job_suspended", "label": "Publish Job Suspended"},
+        {"value": "suspend_publish_job", "label": "Suspend Publish Job"},
     ]
 
 
@@ -102,9 +102,9 @@ class CollectJobInfoItem(BaseSettingsModel):
         "", title="Delay job",
         placeholder="dd:hh:mm:ss"
     )
-    publish_job_suspended: bool = SettingsField(
+    suspend_publish_job: bool = SettingsField(
         False,
-        title="Publish Job Suspended",
+        title="Suspend Publish Job",
         description="Publish job could wait to be manually triggered after quality check"
     )
     use_published: bool = SettingsField(True, title="Use Published scene")
@@ -361,7 +361,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
-          "publish_job_suspended": False,
+          "suspend_publish_job": False,
           "overrides": [
             "department",
             "chunk_size",
@@ -369,7 +369,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
             "priority",
             "primary_pool",
             "secondary_pool",
-            "publish_job_suspended"
+            "suspend_publish_job"
           ],
           "chunk_size": 1,
           "department": "",
@@ -394,7 +394,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
-          "publish_job_suspended": False,
+          "suspend_publish_job": False,
           "overrides": [
             "department",
             "chunk_size",
@@ -402,7 +402,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
             "priority",
             "primary_pool",
             "secondary_pool",
-            "publish_job_suspended"
+            "suspend_publish_job"
           ],
           "chunk_size": 10,
           "department": "",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -40,6 +40,7 @@ def extract_jobinfo_overrides_enum():
         {"value": "secondary_pool", "label": "Secondary pool"},
         {"value": "machine_list", "label": "Machine List"},
         {"value": "machine_list_deny", "label": "Machine List is a Deny"},
+        {"value": "publish_job_suspended", "label": "Publish Job Suspended"},
     ]
 
 
@@ -100,6 +101,11 @@ class CollectJobInfoItem(BaseSettingsModel):
     job_delay: str = SettingsField(
         "", title="Delay job",
         placeholder="dd:hh:mm:ss"
+    )
+    publish_job_suspended: bool = SettingsField(
+        False,
+        title="Publish Job Suspended",
+        description="Publish job could wait to be manually triggered after quality check"
     )
     use_published: bool = SettingsField(True, title="Use Published scene")
     use_asset_dependencies: bool = SettingsField(
@@ -355,13 +361,15 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
+          "publish_job_suspended": False,
           "overrides": [
             "department",
             "chunk_size",
             "group",
             "priority",
             "primary_pool",
-            "secondary_pool"
+            "secondary_pool",
+            "publish_job_suspended"
           ],
           "chunk_size": 1,
           "department": "",
@@ -386,13 +394,15 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
+          "publish_job_suspended": False,
           "overrides": [
             "department",
             "chunk_size",
             "group",
             "priority",
             "primary_pool",
-            "secondary_pool"
+            "secondary_pool",
+            "publish_job_suspended"
           ],
           "chunk_size": 10,
           "department": "",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -40,7 +40,15 @@ def extract_jobinfo_overrides_enum():
         {"value": "secondary_pool", "label": "Secondary pool"},
         {"value": "machine_list", "label": "Machine List"},
         {"value": "machine_list_deny", "label": "Machine List is a Deny"},
-        {"value": "suspend_publish_job", "label": "Suspend Publish Job"},
+        {"value": "publish_job_state ", "label": "Publish Job State"},
+    ]
+
+
+def publish_job_state_enum():
+    """Enum for initial state of publish job"""
+    return [
+        {"value": "active", "label": "Active"},
+        {"value": "suspended", "label": "Suspended"},
     ]
 
 
@@ -102,10 +110,11 @@ class CollectJobInfoItem(BaseSettingsModel):
         "", title="Delay job",
         placeholder="dd:hh:mm:ss"
     )
-    suspend_publish_job: bool = SettingsField(
-        False,
-        title="Suspend Publish Job",
-        description="Publish job could wait to be manually triggered after quality check"
+    publish_job_state : str = SettingsField(
+        enum_resolver=publish_job_state_enum,
+        title="Publish Job State",
+        description="Publish job could wait to be manually enabled from "
+                    "Suspended state after quality check"
     )
     use_published: bool = SettingsField(True, title="Use Published scene")
     use_asset_dependencies: bool = SettingsField(
@@ -361,7 +370,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
-          "suspend_publish_job": False,
+          "publish_job_state": "active",
           "overrides": [
             "department",
             "chunk_size",
@@ -369,7 +378,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
             "priority",
             "primary_pool",
             "secondary_pool",
-            "suspend_publish_job"
+            "publish_job_state"
           ],
           "chunk_size": 1,
           "department": "",
@@ -394,7 +403,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           "group": "",
           "priority": 50,
           "job_delay": "",
-          "suspend_publish_job": False,
+          "publish_job_state": "active",
           "overrides": [
             "department",
             "chunk_size",
@@ -402,7 +411,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
             "priority",
             "primary_pool",
             "secondary_pool",
-            "suspend_publish_job"
+            "publish_job_state"
           ],
           "chunk_size": 10,
           "department": "",


### PR DESCRIPTION
## Changelog Description
Publish job could be set as `Suspended` to allow artist publish only after some necessary checks are made. This was previously possible only in Publisher UI, but even that was removed during refactoring.

Now state of Publish job could be controlled by `Collect Job Info` configuration with Profiles and could be overridden by artist in Publisher UI if necessary.

## Testing notes:
1. experiment with `ayon+settings://deadline/publish/CollectJobInfo/profiles/1/publish_job_state`
![image](https://github.com/user-attachments/assets/44f400c3-9890-4401-a144-e39af34d9e9a)

2. check that values propagate to Publisher UI in DCC, try to change it
3. publish in Deadline and check state of published job in DL Monitor
