### PR TITLE
Add default for `publish_job_state`

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -111,6 +111,7 @@ class CollectJobInfoItem(BaseSettingsModel):
         placeholder="dd:hh:mm:ss"
     )
     publish_job_state : str = SettingsField(
+        "active",
         enum_resolver=publish_job_state_enum,
         title="Publish Job State",
         description="Publish job could wait to be manually enabled from "


### PR DESCRIPTION
## Changelog Description

Add default for `publish_job_state`

## Additional review information

Fixes a case where if existing overrides existed in settings **without** the `publish_job_state` key that it now adds this default value.

Fixes:
```
025-02-18 10:18:47 ERROR      server          Unable to load deadline 0.5.5 settings
    Traceback (most recent call last):
      File "/backend/api/settings/settings.py", line 172, in get_all_settings
        settings = await addon.get_project_settings(project_name, variant)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/backend/ayon_server/addons/addon.py", line 451, in get_project_settings
        settings = await self.get_studio_settings(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/backend/ayon_server/addons/addon.py", line 435, in get_studio_settings
        settings = apply_overrides(settings, overrides)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/backend/ayon_server/settings/overrides.py", line 50, in apply_overrides
        return settings.__class__(**result)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
    pydantic.error_wrappers.ValidationError: 3 validation errors for DeadlineSettings
    publish -> CollectJobInfo -> profiles -> 0 -> publish_job_state
      field required (type=value_error.missing)
    publish -> CollectJobInfo -> profiles -> 1 -> publish_job_state
      field required (type=value_error.missing)
    publish -> CollectJobInfo -> profiles -> 2 -> publish_job_state
      field required (type=value_error.missing)
```


## Testing notes:
1. Have overrides in Collect Job Info profiles before 0.5.5
2. Update to 0.5.5 with copy settings
3. Settings become unaccessible due to the error.
4. This fixes it.