### PR TITLE
Publish job: Ignore unfilled output dir

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -511,12 +511,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "name": product_name,
             "type": product_type,
         }
-        output = None
+
+        render_dir_template = anatomy.get_template_item(
+            "publish", template_name, "directory"
+        )
         try:
-            render_dir_template = anatomy.get_template_item(
-                "publish", template_name, "directory"
-            )
-            output = (
+            return (
                 render_dir_template
                 .format_strict(template_data)
                 .replace("\\", "/")
@@ -527,4 +527,3 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
                 "Publish directory template is unsolved for: "
                 f"{template_name} in anatomy. Output directory won't be set."
             )
-        return output


### PR DESCRIPTION
## Changelog Description
Submit publish job does not set `OutputDirectory` if template cannot be filled.

## Additional review information
The reason why template cannot be filled may wary, one usecase might be that studio uses `{representation}` in directory template, which is not available when submitting job.

## Testing notes:
1. Use `{representation}` in `directory` publish template.
2. Submit job to deadline.
3. Job should be submitted without output directory, and the publishing does not crash.
