### PR TITLE
Fixes LimitGroups and Node-Based LimitGroups in Nuke

### DIFF
--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -643,6 +643,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "ConcurrentTasks": data["concurrent_tasks"],
             "Frames": data.get("frames", ""),
             "Group": cls._sanitize(data["group"]),
+            "LimitGroups": cls._sanitize(data["limit_groups"]),
             "Pool": cls._sanitize(data["primary_pool"]),
             "SecondaryPool": cls._sanitize(data["secondary_pool"]),
 

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -149,7 +149,7 @@ class NukeSubmitDeadline(
                 end=end_frame
             )
         limit_groups = self._get_limit_groups(self.node_class_limit_groups)
-        job_info.LimitGroups = limit_groups
+        job_info.LimitGroups.extend(limit_groups)
 
         render_path = instance.data["path"]
         job_info.Name = os.path.basename(render_path)


### PR DESCRIPTION
## Changelog Description
This fixes LimitGroups not being passed on to the Deadline Job. It also fixes the LimitGroups if `Node Based Limit Groups` are enabled in Nuke.

## Additional testing notes
I think the UI/UX can be better for defining the `Node Based Limit Groups`. At first I confused the Limit Name with the Node Class. 
It's actually not the LimitGroup your set as the value to the LimitGroup key, but the Node Class in Nuke.
![image](https://github.com/user-attachments/assets/16adad41-f103-402c-95ea-0f4c47c3bbc0)

## Testing notes:
1. define Deadline Limit to use in `Collect JobInfo` profiles
2. define custom node-based limit in `Nuke Submit to Deadline` server settings
2. submit to Deadline and check the jobs' limits
