### PR TITLE
Fix: passing of JobDelay and Machine list is a Deny

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -129,7 +129,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             _ = datetime.strptime(formatted_time_string, "%H:%M:%S").time()
             job_info.JobDelay = job_delay
         except ValueError:
-            self.job.warning(
+            self.log.warning(
                 f"Job delay '{job_delay}' doesn't match to "
                 "'dd:hh:mm:ss' format"
             )

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -108,8 +108,10 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         if machine_list:
             if attr_values["machine_list_deny"]:
                 job_info.Blacklist = machine_list
+                job_info.Whitelist = None
             else:
                 job_info.Whitelist = machine_list
+                job_info.Blacklist = None
 
     def _handle_job_delay(self, attr_values, job_info):
         job_delay = attr_values["job_delay"]

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -130,6 +130,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             formatted_time_string = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
             _ = datetime.strptime(formatted_time_string, "%H:%M:%S").time()
             job_info.JobDelay = job_delay
+            job_info.ScheduledType = "Once"
         except ValueError:
             self.log.warning(
                 f"Job delay '{job_delay}' doesn't match to "

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -115,6 +115,8 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
 
     def _handle_job_delay(self, attr_values, job_info):
         job_delay = attr_values["job_delay"]
+        if not job_delay:
+            return
         try:
             parts = job_delay.split(':')
             if len(parts) != 4:

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+from datetime import datetime
 
 import pyblish.api
 from ayon_core.lib import (
@@ -53,6 +54,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         job_info = PublishDeadlineJobInfo.from_attribute_values(attr_values)
 
         self._handle_machine_list(attr_values, job_info)
+        self._handle_job_delay(attr_values, job_info)
 
         self._handle_additional_jobinfo(attr_values, job_info)
 
@@ -108,6 +110,28 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 job_info.Blacklist = machine_list
             else:
                 job_info.Whitelist = machine_list
+
+    def _handle_job_delay(self, attr_values, job_info):
+        job_delay = attr_values["job_delay"]
+        try:
+            parts = job_delay.split(':')
+            if len(parts) != 4:
+                raise ValueError("Invalid format: requires dd:hh:mm:ss")
+
+            _days = int(parts[0])
+            hours = int(parts[1])
+            minutes = int(parts[2])
+            seconds = int(parts[3])
+
+            formatted_time_string = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+            _ = datetime.strptime(formatted_time_string, "%H:%M:%S").time()
+            job_info.JobDelay = job_delay
+        except ValueError:
+            self.job.warning(
+                f"Job delay '{job_delay}' doesn't match to "
+                "'dd:hh:mm:ss' format"
+            )
+            job_info.JobDelay = None
 
     @classmethod
     def apply_settings(cls, project_settings):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -9,11 +9,11 @@ from ayon_server.settings import (
 
 
 class LimitGroupsSubmodel(BaseSettingsModel):
-    _layout = "expanded"
-    name: str = SettingsField(title="Name")
+    _layout = "compact"
+    name: str = SettingsField(title="Group Name")
     value: list[str] = SettingsField(
         default_factory=list,
-        title="Limit Groups"
+        title="Node Classes"
     )
 
 
@@ -247,7 +247,9 @@ class NukeSubmitDeadlineModel(BaseSettingsModel):
     node_class_limit_groups: list[LimitGroupsSubmodel] = SettingsField(
         default_factory=list,
         title="Node based Limit Groups",
-        description="Provide list of node types to get particular limit"
+        description=
+            "Provide list of Nuke node classes to get particular limit group. "
+            "Example: 'OFX.absoft.neatvideo5_v5'"
     )
 
 


### PR DESCRIPTION
## Changelog Description
`JobDelay` wasn't passed in, list of Denied workers weren't passed in

## Additional review information
`JobDelay` is a bit difficult to check, see:
![image](https://github.com/user-attachments/assets/17949818-2a05-47eb-a0c3-f3d1332f54fa)



## Testing notes:
1. experiment with JobDelay and Machine list is a Deny in `Collect JobInfo Settings`
2. check if they are passed in correctly
