### PR TITLE
Version on context could be optional

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -419,9 +419,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "job": render_job or None,
             "instances": instances
         }
-        if instance.context.data.get("version"):
-            # workfile version
-            publish_job["version"] = instance.context.data["version"]
+        collected_version = (
+            instance.data.get("version")   # instance override version
+            or instance.context.data.get("version")   # workfile version
+        )
+        if collected_version:
+            publish_job["version"] = collected_version
 
         if deadline_publish_job_id:
             publish_job["deadline_publish_job_id"] = deadline_publish_job_id

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -414,12 +414,15 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "fps": instance_skeleton_data["fps"],
             "source": instance_skeleton_data["source"],
             "user": instance.context.data["user"],
-            "version": instance.context.data["version"],  # workfile version
             "intent": instance.context.data.get("intent"),
             "comment": instance.context.data.get("comment"),
             "job": render_job or None,
             "instances": instances
         }
+        if instance.context.data.get("version"):
+            # workfile version
+            publish_job["version"] = instance.context.data["version"]
+
         if deadline_publish_job_id:
             publish_job["deadline_publish_job_id"] = deadline_publish_job_id
 


### PR DESCRIPTION
## Changelog Description
`CollectSceneVersion` could be disabled for DCC so version on context might not be collected.

## Additional info
See https://github.com/ynput/ayon-nuke/issues/78 for more details.


## Testing notes:
1. disable `ayon+settings://core/publish/CollectSceneVersion` your DCC of choice (Nuke will ignore it - in `CollectContextData` - different question - PR)
2. publish to DL
3. check version of published files
