### PR TITLE
Fix: if no profiles for CollectJobInfo found

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -11,7 +11,7 @@ from ayon_core.lib import (
 )
 from ayon_core.pipeline.publish import (
     AYONPyblishPluginMixin,
-    KnownPublishError
+    PublishError
 )
 from ayon_core.lib.profiles_filtering import filter_profiles
 from ayon_core.addon import AddonsManager

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -52,7 +52,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
 
         attr_values = self._get_jobinfo_defaults(instance)
         if not attr_values:
-            raise KnownPublishError(
+            raise PublishError(
                 "No profile selected for defaults. Ask Admin to "
                 "fill generic profiles at "
                 "ayon+settings://deadline/publish/CollectJobInfo/profiles"

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -9,7 +9,10 @@ from ayon_core.lib import (
     TextDef,
     UISeparatorDef
 )
-from ayon_core.pipeline.publish import AYONPyblishPluginMixin
+from ayon_core.pipeline.publish import (
+    AYONPyblishPluginMixin,
+    KnownPublishError
+)
 from ayon_core.lib.profiles_filtering import filter_profiles
 from ayon_core.addon import AddonsManager
 
@@ -48,6 +51,12 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             return
 
         attr_values = self._get_jobinfo_defaults(instance)
+        if not attr_values:
+            raise KnownPublishError(
+                "No profile selected for defaults. Ask Admin to "
+                "fill generic profiles at "
+                "ayon+settings://deadline/publish/CollectJobInfo/profiles"
+            )
 
         attr_values.update(self.get_attr_values_from_data(instance.data))
         job_info = PublishDeadlineJobInfo.from_attribute_values(attr_values)


### PR DESCRIPTION
## Changelog Description
Without it fails with weird missing key error ('chunk_size', but might be different). Error message now points to real problem

## Additional review information
Now it fails with 
![image](https://github.com/user-attachments/assets/8f0f6f22-0d0f-4469-a030-7c82cb29af19)


## Testing notes:
1. remove all profiles at `ayon+settings://deadline/publish/CollectJobInfo`
2. try to publish anything to DL, should get better error message
