### PR TITLE
Support farm submissions for `image` product type

### DIFF
--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -32,7 +32,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     label = "Submit Fusion to Deadline"
     order = pyblish.api.IntegratorOrder
     hosts = ["fusion"]
-    families = ["render"]
+    families = ["render", "image"]
     targets = ["local"]
     settings_category = "deadline"
 
@@ -66,7 +66,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         saver_instances = []
         context = instance.context
         for inst in context:
-            if inst.data["productType"] != "render":
+            if inst.data["productType"] in {"image", "render"}:
                 # Allow only saver family instances
                 continue
 


### PR DESCRIPTION
## Changelog Description

Support farm submissions for `image` product type

## Additional review information

Fix https://github.com/ynput/ayon-deadline/issues/140

**Warning!** There is a caveat that the Fusion Deadline Render plug-in renders all tools in one go from one scene, and does not support setting a frame range per tool. Hence, if you were to mix "image" products with "render" products from one comp file and submit them both together - it doesn't actually influence the render frame ranges.

The render frame range is currently taken from the **first** instance. This is also an existing bug with "Render" instances with different frame ranges. 

## Testing notes:

1. Submit "image" products to the farm.
2. Publish should be successful. 