### PR TITLE
Make `Collect Deadline User Credentials` run on all hosts

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -28,15 +28,6 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
     label = "Collect Deadline User Credentials"
 
     targets = ["local"]
-    hosts = ["aftereffects",
-             "blender",
-             "fusion",
-             "harmony",
-             "nuke",
-             "maya",
-             "max",
-             "houdini",
-             "unreal"]
 
     families = FARM_FAMILIES
 


### PR DESCRIPTION
## Changelog Description

Make `Collect Deadline User Credentials` run on all hosts if matching families, like other deadline plug-ins

## Additional review information

Avoids hitting:
```python
Traceback (most recent call last):
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2406251801_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\global\validate_deadline_pools.py", line 42, in process
    instance.data["deadline"]["verify"]
KeyError: 'verify'
```
When working with new hosts.

## Testing notes:

1. Change should be validated in hosts where it previously would not have run.
