### PR TITLE
Write `version` into the publish job metadata if version is 0

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -419,11 +419,15 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "job": render_job or None,
             "instances": instances
         }
-        collected_version = (
-            instance.data.get("version")   # instance override version
-            or instance.context.data.get("version")   # workfile version
-        )
-        if collected_version:
+
+        # Note that a version of 0 is a valid version number,
+        # so we explicitly check for `None` value
+        # instance override version
+        collected_version = instance.data.get("version")
+        if collected_version is None:
+            # workfile version
+            collected_version = instance.context.data.get("version")
+        if collected_version is not None:
             publish_job["version"] = collected_version
 
         if deadline_publish_job_id:


### PR DESCRIPTION
## Changelog Description

Write `version` into the publish job metadata if version is 0

## Additional review information

May fix https://github.com/ynput/ayon-core/issues/1203

## Testing notes:

1. set version start to zero for Nuke _ayon+settings://core/version_start_category_
2. Launch Nuke, publish to farm
3. Publish should succeed and 'version' should be present in metadata.json