### PR TITLE
Maya: Fix submission of tile renders

### DIFF
--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
@@ -25,6 +25,7 @@ from datetime import datetime
 import itertools
 from collections import OrderedDict
 from dataclasses import dataclass, field, asdict
+from typing import Tuple, Dict, Any
 
 from ayon_core.pipeline import (
     AYONPyblishPluginMixin
@@ -36,6 +37,7 @@ from ayon_core.pipeline.farm.tools import iter_expected_files
 from ayon_maya.api.lib_rendersettings import RenderSettings
 from ayon_maya.api.lib import get_attr_in_layer
 
+from ayon_deadline.lib import PublishDeadlineJobInfo
 from ayon_deadline import abstract_submit_deadline
 
 
@@ -244,7 +246,9 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
                         auth=auth,
                         verify=verify)
 
-    def _tile_render(self, payload):
+    def _tile_render(
+        self, payload: Tuple[PublishDeadlineJobInfo, Dict[str, Any]]
+    ):
         """Submit as tile render per frame with dependent assembly jobs."""
 
         # As collected by super process()
@@ -320,7 +324,8 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
                 payload_plugin_info["OutputFilePrefix"]
             )[0]
 
-            new_job_info.update(tiles_data["JobInfo"])
+            for key, value in tiles_data.items():
+                setattr(new_job_info, key, value)
             new_plugin_info.update(tiles_data["PluginInfo"])
 
             self.log.debug("hashing {} - {}".format(file_index, file))


### PR DESCRIPTION
## Changelog Description

Fix submitting of tiled renders from maya.

## Additional review information

Initial draft to try and fix Tile Rendering in Maya submissions

Fix:
```
dependencies/pyblish/plugin.py", line 528, in __explicit_process
    runner(*args)
  File "/home/ralph/.local/share/AYON/addons/deadline_0.5.8/ayon_deadline/abstract_submit_deadline.py", line 125, in process
    job_id = self.process_submission()
  File "/home/ralph/.local/share/AYON/addons/deadline_0.5.8/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py", line 239, in process_submission
    self._tile_render(payload)
  File "/home/ralph/.local/share/AYON/addons/deadline_0.5.8/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py", line 323, in _tile_render
    new_job_info.update(tiles_data["JobInfo"])
AttributeError: 'PublishDeadlineJobInfo' object has no attribute 'update'
```

Reported [here](https://discord.com/channels/517362899170230292/1352616855201644544).

However, this now passes that - but fails on:
```
Traceback (most recent call last):
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2406251801_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "F:\dev/ayon-deadline/client\ayon_deadline\abstract_submit_deadline.py", line 125, in process
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\maya\submit_maya_deadline.py", line 241, in process_submission
    self._tile_render(payload)
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\maya\submit_maya_deadline.py", line 459, in _tile_render
    assembly_job_id = self.submit(
                      ^^^^^^^^^^^^
  File "F:\dev/ayon-deadline/client\ayon_deadline\abstract_submit_deadline.py", line 373, in submit
    self.log.debug(payload)
ayon_core.pipeline.publish.publish_plugins.KnownPublishError: Error: One or more auxiliary files for the job were not successully copied during submission, check for network or server issues and try again. (Deadline.Submission.DeadlineSubmissionException)
```

I'm not sure how this was done before?

## Testing notes:

1. Submitting renders from maya with tiled render checkbox enabled should work
