### PR TITLE
Chore: Add some type hints to `AbstractSubmitDeadline.__init__`

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -4,13 +4,14 @@
 It provides Deadline JobInfo data class.
 
 """
+from __future__ import annotations
 import json.decoder
 from abc import abstractmethod
 import getpass
 import os
 from datetime import datetime
 from copy import deepcopy
-from typing import Optional
+from typing import Any, Optional
 import clique
 
 import requests
@@ -87,12 +88,12 @@ class AbstractSubmitDeadline(
 
     def __init__(self, *args, **kwargs):
         super(AbstractSubmitDeadline, self).__init__(*args, **kwargs)
-        self._instance = None
+        self._instance: Optional[pyblish.api.Instance] = None
         self._deadline_url = None
-        self.scene_path = None
-        self.job_info = None
-        self.plugin_info = None
-        self.aux_files = None
+        self.scene_path: Optional[str] = None
+        self.job_info: Optional[PublishDeadlineJobInfo] = None
+        self.plugin_info: Optional[dict[str, Any]] = None
+        self.aux_files: Optional[list[str]] = None
 
     def process(self, instance):
         """Plugin entry point."""
@@ -293,7 +294,7 @@ class AbstractSubmitDeadline(
         that field even empty must be present on Deadline submission.
 
         Returns:
-            list: List of files.
+            list[str]: List of files.
 
         """
         return []


### PR DESCRIPTION
## Changelog Description

Chore: Add some type hints to `AbstractSubmitDeadline.__init__` so attribute access provide better type hints

## Additional review information

IDE should provide better hints.
Publishing should still work

## Testing notes:

1. Publishing should still work