### PR TITLE
Unreal Engine: Add error handlers for ProRes Error and Windows exit issues 

### DIFF
--- a/client/ayon_deadline/repository/custom/plugins/UnrealEngine5/UnrealEngine5.py
+++ b/client/ayon_deadline/repository/custom/plugins/UnrealEngine5/UnrealEngine5.py
@@ -380,6 +380,18 @@ class UnrealEngineManagedProcess(ManagedProcess):
         logs_dir = self._deadline_plugin.GetPluginInfoEntryWithDefault(
             "LoggingDirectory", ""
         )
+        # error handler for Apple ProRes Media not writing file
+        self.AddStdoutHandlerCallback(
+            ".*LogAppleProResMedia: Error: Failed to.*"
+        ).HandleCallback += self._handle_stdout_error
+
+        self.AddStdoutHandlerCallback(
+            ".*LogWindows: FPlatformMisc::RequestExitWithStatus\(1,.*"
+        ).HandleCallback += self._handle_stdout_error
+
+        self.AddStdoutHandlerCallback(
+            ".*with error DXGI_ERROR_DEVICE_REMOVED with Reason: DXGI_ERROR_DEVICE_HUNG*"
+        ).HandleCallback += self._handle_stdout_error
 
         if logs_dir:
 


### PR DESCRIPTION
## Changelog Description
Handle errors for when ProRes fails to write a file, and errors where the engine closes for some reason.

## Additional review information
Without these error handlers deadline will just spit out a generic error:
```
Only one usage of each socket address (protocol/network address/port) is normally permitted
```
Which doesn't really tell you much.

## Testing notes:
A bit hard to test these ones, but we have been running with these for a while and it makes it easier to tell what is causing the error.
