### PR TITLE
Allow `concurrent_tasks` as exposed override in publisher UI for Collect Job Info

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -305,6 +305,15 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 maximum=1000
             ),
             NumberDef(
+                "concurrent_tasks",
+                label="Concurrent Tasks",
+                description="Number of concurrent tasks to run",
+                default=default_values.get("concurrent_tasks"),
+                decimals=0,
+                minimum=1,
+                maximum=1000
+            ),
+            NumberDef(
                 "priority",
                 label="Priority",
                 default=default_values.get("priority"),

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -307,7 +307,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             NumberDef(
                 "concurrent_tasks",
                 label="Concurrent Tasks",
-                tooltip="Number of concurrent tasks to run",
+                tooltip="Number of concurrent tasks to run per render node",
                 default=default_values.get("concurrent_tasks"),
                 decimals=0,
                 minimum=1,

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -307,7 +307,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             NumberDef(
                 "concurrent_tasks",
                 label="Concurrent Tasks",
-                description="Number of concurrent tasks to run",
+                tooltip="Number of concurrent tasks to run",
                 default=default_values.get("concurrent_tasks"),
                 decimals=0,
                 minimum=1,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -105,7 +105,10 @@ class CollectJobInfoItem(BaseSettingsModel):
         )
     )
     concurrent_tasks: int = SettingsField(
-        1, title="Number of concurrent tasks")
+        1,
+        title="Number of concurrent tasks",
+        description="Concurrent tasks on single render node"
+    )
     department: str = SettingsField("", title="Department")
     job_delay: str = SettingsField(
         "", title="Delay job",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -40,6 +40,7 @@ def extract_jobinfo_overrides_enum():
         {"value": "secondary_pool", "label": "Secondary pool"},
         {"value": "machine_list", "label": "Machine List"},
         {"value": "machine_list_deny", "label": "Machine List is a Deny"},
+        {"value": "concurrent_tasks", "label": "Number of Concurrent Tasks"},
         {"value": "publish_job_state", "label": "Publish Job State"},
     ]
 


### PR DESCRIPTION
## Changelog Description

Allow `concurrent_tasks` as exposed override in publisher UI for Collect Job Info

## Additional review information

Fix #163 

## Testing notes:

1. Enable "Concurrent Tasks" as exposed override in settings.
2. The setting should become visible in publisher UI.
3. It should have the default as the default value set in settings.
4. When changing the value in publisher UI the published job should adhere to the concurrency value.
