### PR TITLE
Run `extractenvironments` only once for rendering job

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_environment_file_to_delete.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_environment_file_to_delete.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Collect persistent environment file to be deleted."""
+import os
+
+import pyblish.api
+
+
+class CollectEnvironmentFileToDelete(pyblish.api.ContextPlugin):
+    """Marks file with extracted environments to be deleted too.
+
+    'GlobalJobPreLoad' produces persistent environment file which gets created
+    only once per OS. This approach limits DB querying, but keeps extracting
+    of environments on render workers, not during submission.
+
+    This file is created next to metadata.json and needs to be removed also.
+    """
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Environment File"
+    targets = ["farm"]
+
+    def process(self, context):
+        for instance in context:
+            is_persistent = instance.data.get("stagingDir_persistent", False)
+            if is_persistent:
+                self.log.debug("Staging dir is persistent, no cleaning.")
+                return
+
+        publish_data_paths = os.environ.get("AYON_PUBLISH_DATA")
+        if not publish_data_paths:
+            self.log.warning("Cannot find folder with metadata files.")
+            return
+
+        anatomy = context.data["anatomy"]
+        paths = publish_data_paths.split(os.pathsep)
+        for path in paths:
+            path = anatomy.fill_root(path)
+            metadata_folder = os.path.dirname(path)
+            for file_name in os.listdir(metadata_folder):
+                if file_name.startswith('extractenvironments'):
+                    file_path = os.path.join(metadata_folder, file_name)
+                    context.data["cleanupFullPaths"].append(file_path)

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -540,12 +540,11 @@ def inject_ayon_environment(deadlinePlugin):
         while os.path.exists(f"{export_url}.tmp"):
             date_diff = datetime.now() - start_time
             if date_diff > timedelta(seconds=EXTRACT_ENVIRONMENT_TIMEOUT):
-                print(
+                raise RuntimeError(
                     "Previous extract environment process stuck for "
                     f"'{EXTRACT_ENVIRONMENT_TIMEOUT}' sec."
                     "Starting it from scratch."
                 )
-                break
             print("Extract environment process already triggered, waiting")
             sleep(2)
 

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -522,6 +522,7 @@ def inject_ayon_environment(deadlinePlugin):
             ))
 
         output_urls = ["OutputFilePath", "Output", "SceneFile"]
+        output_dir = None
         for output in output_urls:
             output_dir = job.GetJobPluginInfoKeyValue(output)
             if output_dir:

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -561,9 +561,6 @@ def inject_ayon_environment(deadlinePlugin):
             print(">>> Setting script path {}".format(script_url))
             job.SetJobPluginInfoKeyValue("ScriptFilename", script_url)
 
-        # print(">>> Removing temporary file")
-        # os.remove(export_url)
-
         print(">> Injection end.")
     except Exception as e:
         if hasattr(e, "output"):

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -521,12 +521,7 @@ def inject_ayon_environment(deadlinePlugin):
                 "AYON_SERVER_URL and AYON_API_KEY"
             ))
 
-        output_urls = ["OutputFilePath", "Output", "SceneFile"]
-        output_dir = None
-        for output in output_urls:
-            output_dir = job.GetJobPluginInfoKeyValue(output)
-            if output_dir:
-                break
+        output_dir = _get_output_dir(job)
 
         export_url = _get_export_path(output_dir)
 
@@ -604,6 +599,20 @@ def _get_export_path(output_dir):
     return export_url
 
 
+def _get_output_dir(job):
+    """Look for output dir where metadata.json should be created also."""
+    output_urls = ["OutputFilePath", "Output", "SceneFile"]
+    output_dir = None
+    for output in output_urls:
+        output_dir = job.GetJobPluginInfoKeyValue(output)
+        if output_dir:
+            break
+    if not output_dir:
+        raise RuntimeError(
+            "Unable to find workfile location or "
+            "location where files should be rendered.")
+    output_dir = os.path.dirname(output_dir)
+    return output_dir
 
 
 def _extractenvironments(


### PR DESCRIPTION
## Changelog Description
Previous implementation ran `extractenvironments` CLI command for each of the Deadline workers. Internal query for getting all environment variables is quite an expensive one, which resulted in poor performance of AYON server.

This PR persists result of `extractenvironments`, it separates different OS of workers in separate files which will be picked by appropriate workers automatically.

`extractenvironments` file should be stored next to `metadata.json` (which should be next to rendered files)

## Additional review information
As `extractenvironments` is expensive operation, first worker node which wants to start it creates empty `extractenvironments_{OS}.txt.tmp` before calling CLI. All other nodes are looking for that file, if found, they will wait for first render node to finish extraction process and renaming that file to `extractenvironments_{OS}.txt`.

Testing might be a bit complicated on one render nodes Deadlines.

## Testing notes:
1. you could start multiple render workers on your DL repository if desired, firstly it is required to enable `Launch New Named Worker` which is disabled by default
![image](https://github.com/user-attachments/assets/7817e2c9-009f-4ed4-9016-21c2c02a77b1)
(restart Monitor)
2. after that new options should appear in Deadline Launcher (hidden in your Windows tray)
![image](https://github.com/user-attachments/assets/a4efe0b3-8df8-4024-95ed-f5f376750104)
3. you need to split job into multiple tasks in Publisher UI
![image](https://github.com/user-attachments/assets/96e967ed-9105-4b5f-b178-c280b0954ee2)
4. you could watch AYON server DB performance, but I tested it by adding temporary logging to `ayon-applications/client/ayon_applications/addon.py:_cli_extract_environments`
```
        with open("c:/projects/extract.txt", "a") as fp:
            fp.write("_cli_extract_environments called\n")
```
![image](https://github.com/user-attachments/assets/84268f5b-6f3d-4180-b46d-fb9484088c77)

