### PR TITLE
Fix submission from fusion when submitting multiple instances

### DIFF
--- a/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
+++ b/client/ayon_deadline/plugins/publish/fusion/submit_fusion_deadline.py
@@ -66,7 +66,7 @@ class FusionSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         saver_instances = []
         context = instance.context
         for inst in context:
-            if inst.data["productType"] in {"image", "render"}:
+            if inst.data["productType"] not in {"image", "render"}:
                 # Allow only saver family instances
                 continue
 


### PR DESCRIPTION
## Changelog Description

Fix submission from fusion when submitting multiple instances

## Additional review information

Fix product type check condition.

Avoids error:
```
Traceback (most recent call last):
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\dependency_packages\ayon_2407291312_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\deadline_0.5.10+cb.1\ayon_deadline\plugins\publish\global\submit_publish_job.py", line 361, in process
    representations = prepare_representations(
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\core_1.1.7+cb.1\ayon_core\pipeline\farm\pyblish_functions.py", line 342, in prepare_representations
    frames_to_render = convert_frames_str_to_list(frames_to_render)
  File "C:\Users\Maqina-RTX-05\AppData\Local\Ynput\AYON\addons\core_1.1.7+cb.1\ayon_core\pipeline\farm\pyblish_functions.py", line 520, in convert_frames_str_to_list
    output.append(int(frame))
ValueError: invalid literal for int() with base 10: ''
```

When submitting multiple instances to the farm at the same time.

## Testing notes:

1. Fix deadline submission from fusion from multiple instances at the same time.
