### PR TITLE
Maya: Patch workfile - fix comparison for `.ma` file extension

### DIFF
--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py
@@ -631,7 +631,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if not patches:
             return
 
-        if not os.path.splitext(self.scene_path)[1].lower() != ".ma":
+        if os.path.splitext(self.scene_path)[1].lower() != ".ma":
             self.log.debug("Skipping workfile patch since workfile is not "
                            ".ma file")
             return


### PR DESCRIPTION
## Changelog Description

Maya: Patch workfile - fix comparison for `.ma` file extension

Otherwise it'd run on `.mb` files and error and never be able to run on a `.ma` either. So basically this feature has been broken in... forever?

## Additional review information

Came up internally [here](https://discord.com/channels/517362899170230292/1364938325873524848/1364940468814876672) (private conversation)

Example traceback when running on `.mb` file:
```python
//   File "/usr/autodesk/maya2025/lib/python3.11/encodings/ascii.py", line 26, in decode
//     return codecs.ascii_decode(input, self.errors)[0]
//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
// UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 35: ordinal not in range(128)
// Traceback (most recent call last):
//   File "/mnt/AYON/dependency_packages/ayon_2406260959_linux-centos7.zip/dependencies/pyblish/plugin.py", line 528, in __explicit_process
//     runner(*args)
//   File "/mnt/AYON/addons/deadline_0.4.0/ayon_deadline/abstract_submit_deadline.py", line 465, in process
//     job_id = self.process_submission()
//              ^^^^^^^^^^^^^^^^^^^^^^^^^
//   File "/mnt/AYON/addons/deadline_0.4.0/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py", line 289, in process_submission
//     self._patch_workfile()
//   File "/mnt/AYON/addons/deadline_0.4.0/ayon_deadline/plugins/publish/maya/submit_maya_deadline.py", line 739, in _patch_workfile
//     scene_data = pf.readlines()
//                  ^^^^^^^^^^^^^^
//   File "/usr/autodesk/maya2025/lib/python3.11/encodings/ascii.py", line 26, in decode
//     return codecs.ascii_decode(input, self.errors)[0]
//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
// UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 35: ordinal not in range(128)
```

## Testing notes:

1. Patch workfile should work with `.ma`
2. Patch workfile should be skipped for `.mb`
