### PR TITLE
Validate Expected Files: log directory that is searched in

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
+++ b/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py
@@ -43,6 +43,7 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
             expected_files = self._get_expected_files(repre)
 
             staging_dir = repre["stagingDir"]
+            self.log.debug(f"Validating files in directory: {staging_dir}")
             existing_files = self._get_existing_files(staging_dir)
 
             is_image = f'.{repre["ext"]}' in IMAGE_EXTENSIONS


### PR DESCRIPTION
## Changelog Description

Log which folder the expected files are searched for.

Without this it can be quite hard from just the publish logs alone to figure out which file AYON actually ended up looking in. This will make it much easier to find out directly before a potential invalidation happens.

## Additional review information

Helps debugging when files are not found.

## Testing notes:

1. Check the code and logged message?