### PR TITLE
After Effects: Fix `MULTIPROCESS` env var being required to avoid bug

### DIFF
--- a/client/ayon_deadline/plugins/publish/aftereffects/submit_aftereffects_deadline.py
+++ b/client/ayon_deadline/plugins/publish/aftereffects/submit_aftereffects_deadline.py
@@ -20,7 +20,7 @@ class DeadlinePluginInfo():
     ProjectPath: str = field(default=None)
     AWSAssetFile0: str = field(default=None)
     Version: str = field(default=None)
-    MultiProcess: str = field(default=None)
+    MultiProcess: bool = field(default=None)
 
 
 class AfterEffectsSubmitDeadline(
@@ -34,6 +34,8 @@ class AfterEffectsSubmitDeadline(
     use_published = True
     targets = ["local"]
     settings_category = "deadline"
+
+    multiprocess: bool = True
 
     def get_job_info(self, job_info=None):
         job_info.Plugin = "AfterEffects"


### PR DESCRIPTION
## Changelog Description

Fix `self.multiprocess` not being set + fix type hint for DeadlinePlu…ginInfo.MultiProcess to be `bool`

## Additional review information

I'm not sure about the type hint change to `bool` - should it remain `str` instead?

## Testing notes:
1. Publishing to deadline with After Effects should work, even without `MULTIPROCESS` env var set.
