### PR TITLE
Blender: Submit only one render job, even if multiple instances

### DIFF
--- a/client/ayon_deadline/plugins/publish/blender/submit_blender_deadline.py
+++ b/client/ayon_deadline/plugins/publish/blender/submit_blender_deadline.py
@@ -24,7 +24,57 @@ class BlenderSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     families = ["render"]  # TODO this should be farm specific as render.farm
     settings_category = "deadline"
 
-    def get_job_info(self, job_info=None):
+    def process(self, instance):
+        if not instance.data.get("farm"):
+            self.log.debug("Render on farm is disabled. "
+                           "Skipping deadline submission.")
+            return
+
+        # We are submitting a farm job not per instance - but once per Blender
+        # scene. This is a hack to avoid submitting multiple jobs for each
+        # comp file output because the Deadline job will always render all
+        # active ones anyway (and the relevant view layers).
+        context = instance.context
+        key = "__hasRun{}".format(self.__class__.__name__)
+        if context.data.get(key, False):
+            return
+        else:
+            context.data[key] = True
+
+        # Collect all saver instances in context that are to be rendered
+        render_instances = []
+        context = instance.context
+        for inst in context:
+            if inst.data["productType"] != "render":
+                # Allow only render instances
+                continue
+
+            if not inst.data.get("publish", True):
+                # Skip inactive instances
+                continue
+
+            if not inst.data.get("farm"):
+                # Only consider instances that are also set to be rendered on
+                # farm
+                continue
+
+            render_instances.append(inst)
+
+        if not render_instances:
+            raise RuntimeError("No instances found for Deadline submission")
+
+        instance.data["_farmRenderInstances"] = render_instances
+
+        super().process(instance)
+
+        # Store the response for dependent job submission plug-ins for all
+        # the instances
+        transfer_keys = ["deadlineSubmissionJob", "deadline"]
+        for render_instance in render_instances:
+            for key in transfer_keys:
+                render_instance.data[key] = instance.data[key]
+
+    def get_job_info(self, job_info=None, **kwargs):
         instance = self._instance
         job_info.Plugin = instance.data.get("blenderRenderPlugin", "Blender")
 
@@ -37,6 +87,16 @@ class BlenderSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
                 step=int(instance.data["byFrameStep"]),
             )
             job_info.Frames = frames
+
+        # We override the default behavior of AbstractSubmitDeadline here to
+        # include the output directory and output filename for each individual
+        # render instance, instead of only the current instance, because we're
+        # submitting one job for multiple render instances.
+        for render_instance in instance.data["_farmRenderInstances"]:
+            if render_instance is instance:
+                continue
+
+            self._append_job_output_paths(instance, job_info)
 
         return job_info
 


### PR DESCRIPTION
## Changelog Description

Only ever submit a single deadline render job, because all render instances (all view layers + comp file output nodes) will be rendered for each deadline job anyway. As such, rendering it more than once makes no sense.

## Additional review information

See issue reported [here](https://github.com/ynput/ayon-blender/pull/67#issuecomment-3057628484) by @jrsndl

## Testing notes:

1. Even with multiple render instances, only a single render job should be submitted.
2. Publish jobs should still work separately however.
