### PR TITLE
Artists can override selected Deadline server

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -10,9 +10,11 @@ Provides:
     instance.data["deadline"] -> auth (tuple (str, str)) -
         (username, password) or None
 """
+import os
+
 import pyblish.api
 
-from ayon_api import get_server_api_connection
+from ayon_api import get_addon_site_settings
 
 from ayon_deadline.lib import FARM_FAMILIES
 
@@ -91,10 +93,9 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
                 default_username, default_password
             )
 
-        # TODO import 'get_addon_site_settings' when available
-        #   in public 'ayon_api'
-        local_settings = get_server_api_connection().get_addon_site_settings(
-            deadline_addon.name, deadline_addon.version)
+        site_id = os.environ["AYON_SITE_ID"]
+        local_settings = get_addon_site_settings(
+            deadline_addon.name, deadline_addon.version, site_id)
         local_settings = local_settings["local_settings"]
         for server_info in local_settings:
             if deadline_server_name == server_info["server_name"]:

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -65,10 +65,12 @@ class DeadlineSettings(BaseSettingsModel):
 
     # name(key) of selected server for project
     deadline_server: str = SettingsField(
-        title="Project Deadline server name",
+        title="Selected Deadline server name",
         section="---",
-        scope=["project"],
-        enum_resolver=defined_deadline_ws_name_enum_resolver
+        scope=["project", "site"],
+        enum_resolver=defined_deadline_ws_name_enum_resolver,
+        description="Select one from predefined Deadline servers from Studio "
+                    "Settings to be used for this Project"
     )
 
     publish: PublishPluginsModel = SettingsField(

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -17,14 +17,12 @@ from .publish_plugins import (
 
 async def defined_deadline_ws_name_enum_resolver(
     addon: "BaseServerAddon",
-    settings_variant: str = "production",
-    project_name: str | None = None,
 ) -> list[str]:
     """Provides list of names of configured Deadline webservice urls."""
     if addon is None:
         return []
 
-    settings = await addon.get_studio_settings(variant=settings_variant)
+    settings = await addon.get_studio_settings()
 
     ws_server_name = []
     for deadline_url_item in settings.deadline_urls:


### PR DESCRIPTION
## Changelog Description
Fixed displaying all configured Deadline servers from `Studio Settings` and enhancing `Project Settings` `Site Settings` to allow artists (freelancers) to use different than selected DL server on the project. 

(Maybe freelancers need to use different exposed IP or port.)

## Additional review information
Enhancing of `Project Settings` `Site Settings` was selected as it automatically propagates value configured on `Project Settings`. 
Another option would be `Studio Settings` . `Site Settings` would be more complicated as it requires default value which would need to be hardcoded and maybe non existent. (If 'default' would be used, we cannot rely that 'default' actually exists and no studio admin wouldn't rename it right away.)

## Testing notes:
1. configure more DL servers in `ayon+settings://deadline/deadline_urls`
2. select newly created server in `ayon+settings://deadline/deadline_server?project=YOUR_PROJECT&site=YOUR_SITE_ID`
3. check that `Deadline Webservice from the Instance` chose artist overridden value
