### PR TITLE
Implementation of clean up collector for blender temp folder during farm

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_clean_up_files.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_clean_up_files.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Collect persistent environment file to be deleted."""
+import os
+from typing import List, Dict
+import pyblish.api
+
+
+class CollectCleanUpForBlender(pyblish.api.InstancePlugin):
+    """Collect files and directories to be cleaned up.
+    """
+
+    order = pyblish.api.CollectorOrder - 0.1
+    label = "Collect Clean Up (Blender)"
+    targets = ["farm"]
+
+    def process(self, instance):
+        representations : List[Dict] = instance.data.get("representations", [])
+        staging_dirs: List[str] = []
+        files : List[str] = []
+        for repre in representations:
+            staging_dir = repre.get("stagingDir")
+            blender_tmp_dir = os.path.join(staging_dir, "tmp")
+            if not os.path.exists(blender_tmp_dir):
+                continue
+            staging_dirs.append(blender_tmp_dir)
+            for tmp_file in os.listdir(blender_tmp_dir):
+                files.append(os.path.join(blender_tmp_dir, tmp_file))
+
+        instance.context.data["cleanupFullPaths"].extend(files)
+        self.log.debug(f"Files to clean up: {files}")
+        instance.context.data["cleanupEmptyDirs"].extend(staging_dirs)
+        self.log.debug(f"Staging dirs to clean up: {staging_dirs}")


### PR DESCRIPTION
## Changelog Description
This PR is to make sure blender temporary scene render directory as clean up path/directory during submit publish job.

## Additional review information
Enable ayon+settings://core/publish/CollectRenderedFiles/remove_files so that it can also remove along with the rendered files.

## Testing notes:
1. Publish Render instance from Blender
2. Check if the render output directory e.g. `renders/blender/il_lib_art_v070` if it still exists