### PR TITLE
Fix: AYON_API_KEY from Additional AYON Servers is used for Publish jobs

### DIFF
--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -70,7 +70,7 @@ class AyonDeadlinePlugin(DeadlinePlugin):
 
         # set required env vars for AYON
         # cannot be in InitializeProcess as it is too soon
-        ayon_api_key, ayon_server_url = handle_credentials(job)
+        ayon_server_url, ayon_api_key = handle_credentials(job)
 
         ayon_bundle_name = job.GetJobEnvironmentKeyValue("AYON_BUNDLE_NAME")
 

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -14,7 +14,7 @@ import re
 import os
 import platform
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 ######################################################################
 # This is the function that Deadline calls to get an instance of the
@@ -70,15 +70,8 @@ class AyonDeadlinePlugin(DeadlinePlugin):
 
         # set required env vars for AYON
         # cannot be in InitializeProcess as it is too soon
-        config = RepositoryUtils.GetPluginConfig("Ayon")  # plugin name stays
-        ayon_server_url = (
-                job.GetJobEnvironmentKeyValue("AYON_SERVER_URL") or
-                config.GetConfigEntryWithDefault("AyonServerUrl", "")
-        )
-        ayon_api_key = (
-                job.GetJobEnvironmentKeyValue("AYON_API_KEY") or
-                config.GetConfigEntryWithDefault("AyonApiKey", "")
-        )
+        ayon_api_key, ayon_server_url = handle_credentials(job)
+
         ayon_bundle_name = job.GetJobEnvironmentKeyValue("AYON_BUNDLE_NAME")
 
         environment = {
@@ -157,3 +150,85 @@ class AyonDeadlinePlugin(DeadlinePlugin):
     def HandleProgress(self):
         progress = float(self.GetRegexMatch(1))
         self.SetProgress(progress)
+
+
+def handle_credentials(job):
+    config = RepositoryUtils.GetPluginConfig("Ayon")
+    ayon_server_url = config.GetConfigEntryWithDefault("AyonServerUrl", "")
+    ayon_api_key = config.GetConfigEntryWithDefault("AyonApiKey", "")
+
+    job_ayon_server_url = job.GetJobEnvironmentKeyValue("AYON_SERVER_URL")
+    job_ayon_api_key = job.GetJobEnvironmentKeyValue("AYON_API_KEY")
+
+    # API key submitted with job environment will always take priority
+    if job_ayon_api_key:
+        ayon_api_key = job_ayon_api_key
+
+    # Allow custom AYON API key per server URL if server URL is submitted
+    # along with the job. The custom API keys can be configured on the
+    # Deadline Repository AYON Plug-in settings, in the format of
+    # `SERVER:PORT@APIKEY` per line.
+    elif job_ayon_server_url and job_ayon_server_url != ayon_server_url:
+        api_key = _get_ayon_api_key_from_additional_servers(
+            config, job_ayon_server_url)
+        if api_key:
+            ayon_api_key = api_key
+            print("Using API key from Additional AYON Servers.")
+        else:
+            print(
+                "AYON Server URL submitted with job "
+                f"'{job_ayon_server_url}' has no API key defined "
+                "in AYON Deadline plugin configuration,"
+                " `Additional AYON Servers` section."
+                " Use Deadline monitor to modify the values."
+                "Falling back to `AYON API key` set in `AYON Credentials`"
+                " section of AYON plugin configuration."
+            )
+        ayon_server_url = job_ayon_server_url
+    if not all([ayon_server_url, ayon_api_key]):
+        raise RuntimeError(
+            "Missing required values for server url and api key. "
+            "Please fill in AYON Deadline plugin or provide by "
+            "AYON_SERVER_URL and AYON_API_KEY"
+        )
+    return ayon_server_url, ayon_api_key
+
+
+def _get_ayon_api_key_from_additional_servers(config, server):
+    """Get AYON API key from the list of additional servers.
+
+    The additional servers are configured on the DeadlineRepository AYON
+    Plug-in settings using the `AyonAdditionalServerUrls` param. Each line
+    represents a server URL with an API key, like:
+        server1:port@APIKEY1
+        server2:port@APIKEY2
+
+    Returns:
+        Optional[str]: If the server URL is found in the additional servers
+            then return the API key for that server.
+
+    """
+    additional_servers: str = config.GetConfigEntryWithDefault(
+        "AyonAdditionalServerUrls", "").strip()
+    if not additional_servers:
+        return
+
+    if not isinstance(additional_servers, list):
+        additional_servers = additional_servers.split(";")
+
+    for line in additional_servers:
+        line = line.strip()
+        # Ignore empty lines
+        if not line:
+            continue
+
+        # Log warning if additional server URL is misconfigured
+        # without an API key
+        if "@" not in line:
+            print("Configured additional server URL lacks "
+                  f"`@APIKEY` suffix: {line}")
+            continue
+
+        additional_server, api_key = line.split("@", 1)
+        if additional_server == server:
+            return api_key

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -153,6 +153,12 @@ class AyonDeadlinePlugin(DeadlinePlugin):
 
 
 def handle_credentials(job):
+    """Returns a tuple of values for AYON_SERVER_URL and AYON_API_KEY
+
+    AYON_API_KEY might be overridden directly from job environments.
+    Or specific AYON_SERVER_URL might be attached to job to pick corespondent
+    AYON_API_KEY from plugin configuration.
+    """
     config = RepositoryUtils.GetPluginConfig("Ayon")
     ayon_server_url = config.GetConfigEntryWithDefault("AyonServerUrl", "")
     ayon_api_key = config.GetConfigEntryWithDefault("AyonApiKey", "")

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -179,10 +179,10 @@ def handle_credentials(job):
             config, job_ayon_server_url)
         if api_key:
             ayon_api_key = api_key
-            print("Using API key from Additional AYON Servers.")
+            print(">>> Using API key from Additional AYON Servers.")
         else:
             print(
-                "AYON Server URL submitted with job "
+                ">>> AYON Server URL submitted with job "
                 f"'{job_ayon_server_url}' has no API key defined "
                 "in AYON Deadline plugin configuration,"
                 " `Additional AYON Servers` section."

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -70,7 +70,15 @@ class AyonDeadlinePlugin(DeadlinePlugin):
 
         # set required env vars for AYON
         # cannot be in InitializeProcess as it is too soon
-        ayon_server_url, ayon_api_key = handle_credentials(job)
+        config = RepositoryUtils.GetPluginConfig("Ayon")  # plugin name stays
+        ayon_server_url = (
+            job.GetJobEnvironmentKeyValue("AYON_SERVER_URL")
+            or config.GetConfigEntryWithDefault("AyonServerUrl", "")
+        )
+        ayon_api_key = (
+            job.GetJobEnvironmentKeyValue("AYON_API_KEY")
+            or config.GetConfigEntryWithDefault("AyonApiKey", "")
+        )
 
         ayon_bundle_name = job.GetJobEnvironmentKeyValue("AYON_BUNDLE_NAME")
 
@@ -150,91 +158,3 @@ class AyonDeadlinePlugin(DeadlinePlugin):
     def HandleProgress(self):
         progress = float(self.GetRegexMatch(1))
         self.SetProgress(progress)
-
-
-def handle_credentials(job):
-    """Returns a tuple of values for AYON_SERVER_URL and AYON_API_KEY
-
-    AYON_API_KEY might be overridden directly from job environments.
-    Or specific AYON_SERVER_URL might be attached to job to pick corespondent
-    AYON_API_KEY from plugin configuration.
-    """
-    config = RepositoryUtils.GetPluginConfig("Ayon")
-    ayon_server_url = config.GetConfigEntryWithDefault("AyonServerUrl", "")
-    ayon_api_key = config.GetConfigEntryWithDefault("AyonApiKey", "")
-
-    job_ayon_server_url = job.GetJobEnvironmentKeyValue("AYON_SERVER_URL")
-    job_ayon_api_key = job.GetJobEnvironmentKeyValue("AYON_API_KEY")
-
-    # API key submitted with job environment will always take priority
-    if job_ayon_api_key:
-        ayon_api_key = job_ayon_api_key
-
-    # Allow custom AYON API key per server URL if server URL is submitted
-    # along with the job. The custom API keys can be configured on the
-    # Deadline Repository AYON Plug-in settings, in the format of
-    # `SERVER:PORT@APIKEY` per line.
-    elif job_ayon_server_url and job_ayon_server_url != ayon_server_url:
-        api_key = _get_ayon_api_key_from_additional_servers(
-            config, job_ayon_server_url)
-        if api_key:
-            ayon_api_key = api_key
-            print(">>> Using API key from Additional AYON Servers.")
-        else:
-            print(
-                ">>> AYON Server URL submitted with job "
-                f"'{job_ayon_server_url}' has no API key defined "
-                "in AYON Deadline plugin configuration,"
-                " `Additional AYON Servers` section."
-                " Use Deadline monitor to modify the values."
-                "Falling back to `AYON API key` set in `AYON Credentials`"
-                " section of AYON plugin configuration."
-            )
-        ayon_server_url = job_ayon_server_url
-    if not all([ayon_server_url, ayon_api_key]):
-        raise RuntimeError(
-            "Missing required values for server url and api key. "
-            "Please fill in AYON Deadline plugin or provide by "
-            "AYON_SERVER_URL and AYON_API_KEY"
-        )
-    return ayon_server_url, ayon_api_key
-
-
-def _get_ayon_api_key_from_additional_servers(config, server):
-    """Get AYON API key from the list of additional servers.
-
-    The additional servers are configured on the DeadlineRepository AYON
-    Plug-in settings using the `AyonAdditionalServerUrls` param. Each line
-    represents a server URL with an API key, like:
-        server1:port@APIKEY1
-        server2:port@APIKEY2
-
-    Returns:
-        Optional[str]: If the server URL is found in the additional servers
-            then return the API key for that server.
-
-    """
-    additional_servers: str = config.GetConfigEntryWithDefault(
-        "AyonAdditionalServerUrls", "").strip()
-    if not additional_servers:
-        return
-
-    if not isinstance(additional_servers, list):
-        additional_servers = additional_servers.split(";")
-
-    for line in additional_servers:
-        line = line.strip()
-        # Ignore empty lines
-        if not line:
-            continue
-
-        # Log warning if additional server URL is misconfigured
-        # without an API key
-        if "@" not in line:
-            print("Configured additional server URL lacks "
-                  f"`@APIKEY` suffix: {line}")
-            continue
-
-        additional_server, api_key = line.split("@", 1)
-        if additional_server == server:
-            return api_key

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/__init__.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/__init__.py
@@ -1,5 +1,0 @@
-from .Ayon import handle_credentials
-
-__all__ = [
-    "handle_credentials",
-]

--- a/client/ayon_deadline/repository/custom/plugins/Ayon/__init__.py
+++ b/client/ayon_deadline/repository/custom/plugins/Ayon/__init__.py
@@ -1,0 +1,5 @@
+from .Ayon import handle_credentials
+
+__all__ = [
+    "handle_credentials",
+]

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -1,7 +1,6 @@
 # /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
-import sys
 import tempfile
 from datetime import datetime, timedelta
 import subprocess
@@ -12,26 +11,12 @@ import re
 from time import sleep
 import getpass
 from hashlib import sha256
-import importlib.util
 
 from Deadline.Scripting import (
     RepositoryUtils,
     FileUtils,
     DirectoryUtils,
 )
-
-
-def import_from_path(module_name, file_path):
-    spec = importlib.util.spec_from_file_location(module_name, file_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-pluginName = 'Ayon'  # The other plugin you want to import from
-pluginsDir = RepositoryUtils.GetCustomPluginsDirectory()
-pluginFile = os.path.join(pluginsDir, pluginName, pluginName + ".py")
-ayon_module = import_from_path(pluginName, pluginFile)
 
 
 __version__ = "1.2.3"

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -730,43 +730,6 @@ def inject_render_job_id(deadlinePlugin):
     print(">>> Injection end.")
 
 
-def __main__(deadlinePlugin):
-    print("*** GlobalJobPreload {} start ...".format(__version__))
-    print(">>> Getting job ...")
-    job = deadlinePlugin.GetJob()
-
-    openpype_render_job = job.GetJobEnvironmentKeyValue(
-        "OPENPYPE_RENDER_JOB")
-    openpype_publish_job = job.GetJobEnvironmentKeyValue(
-        "OPENPYPE_PUBLISH_JOB")
-    openpype_remote_job = job.GetJobEnvironmentKeyValue(
-        "OPENPYPE_REMOTE_PUBLISH")
-
-    if openpype_publish_job == "1" and openpype_render_job == "1":
-        raise RuntimeError(
-            "Misconfiguration. Job couldn't be both render and publish."
-        )
-
-    if openpype_publish_job == "1":
-        inject_render_job_id(deadlinePlugin)
-    if openpype_render_job == "1" or openpype_remote_job == "1":
-        inject_openpype_environment(deadlinePlugin)
-
-    ayon_render_job = job.GetJobEnvironmentKeyValue("AYON_RENDER_JOB")
-    ayon_publish_job = job.GetJobEnvironmentKeyValue("AYON_PUBLISH_JOB")
-    ayon_remote_job = job.GetJobEnvironmentKeyValue("AYON_REMOTE_PUBLISH")
-
-    if ayon_publish_job == "1" and ayon_render_job == "1":
-        raise RuntimeError(
-            "Misconfiguration. Job couldn't be both render and publish."
-        )
-
-    if ayon_publish_job == "1":
-        inject_render_job_id(deadlinePlugin)
-    if ayon_render_job == "1" or ayon_remote_job == "1":
-        inject_ayon_environment(deadlinePlugin)
-
-
 def handle_credentials(job):
     """Returns a tuple of values for AYON_SERVER_URL and AYON_API_KEY
 
@@ -853,3 +816,40 @@ def _get_ayon_api_key_from_additional_servers(config, server):
         additional_server, api_key = line.split("@", 1)
         if additional_server == server:
             return api_key
+
+
+def __main__(deadlinePlugin):
+    print("*** GlobalJobPreload {} start ...".format(__version__))
+    print(">>> Getting job ...")
+    job = deadlinePlugin.GetJob()
+
+    openpype_render_job = job.GetJobEnvironmentKeyValue(
+        "OPENPYPE_RENDER_JOB")
+    openpype_publish_job = job.GetJobEnvironmentKeyValue(
+        "OPENPYPE_PUBLISH_JOB")
+    openpype_remote_job = job.GetJobEnvironmentKeyValue(
+        "OPENPYPE_REMOTE_PUBLISH")
+
+    if openpype_publish_job == "1" and openpype_render_job == "1":
+        raise RuntimeError(
+            "Misconfiguration. Job couldn't be both render and publish."
+        )
+
+    if openpype_publish_job == "1":
+        inject_render_job_id(deadlinePlugin)
+    if openpype_render_job == "1" or openpype_remote_job == "1":
+        inject_openpype_environment(deadlinePlugin)
+
+    ayon_render_job = job.GetJobEnvironmentKeyValue("AYON_RENDER_JOB")
+    ayon_publish_job = job.GetJobEnvironmentKeyValue("AYON_PUBLISH_JOB")
+    ayon_remote_job = job.GetJobEnvironmentKeyValue("AYON_REMOTE_PUBLISH")
+
+    if ayon_publish_job == "1" and ayon_render_job == "1":
+        raise RuntimeError(
+            "Misconfiguration. Job couldn't be both render and publish."
+        )
+
+    if ayon_publish_job == "1":
+        inject_render_job_id(deadlinePlugin)
+    if ayon_render_job == "1" or ayon_remote_job == "1":
+        inject_ayon_environment(deadlinePlugin)

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -17,7 +17,10 @@ from Deadline.Scripting import (
     FileUtils,
     DirectoryUtils,
 )
-__version__ = "1.2.2"
+
+from Deadline.Plugins.Ayon import handle_credentials
+
+__version__ = "1.2.3"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"
@@ -415,46 +418,6 @@ def inject_openpype_environment(deadlinePlugin):
         raise
 
 
-def get_ayon_api_key_from_additional_servers(config, server):
-    """Get AYON API key from the list of additional servers.
-
-    The additional servers are configured on the DeadlineRepository AYON
-    Plug-in settings using the `AyonAdditionalServerUrls` param. Each line
-    represents a server URL with an API key, like:
-        server1:port@APIKEY1
-        server2:port@APIKEY2
-
-    Returns:
-        Optional[str]: If the server URL is found in the additional servers
-            then return the API key for that server.
-
-    """
-    additional_servers: str = config.GetConfigEntryWithDefault(
-        "AyonAdditionalServerUrls", "").strip()
-    if not additional_servers:
-        return
-
-    if not isinstance(additional_servers, list):
-        additional_servers = additional_servers.split(";")
-
-    for line in additional_servers:
-        line = line.strip()
-        # Ignore empty lines
-        if not line:
-            continue
-
-        # Log warning if additional server URL is misconfigured
-        # without an API key
-        if "@" not in line:
-            print("Configured additional server URL lacks "
-                  f"`@APIKEY` suffix: {line}")
-            continue
-
-        additional_server, api_key = line.split("@", 1)
-        if additional_server == server:
-            return api_key
-
-
 def inject_ayon_environment(deadlinePlugin):
     """ Pull env vars from AYON and push them to rendering process.
 
@@ -483,44 +446,7 @@ def inject_ayon_environment(deadlinePlugin):
                 "Missing env var in job properties AYON_BUNDLE_NAME"
             )
 
-        config = RepositoryUtils.GetPluginConfig("Ayon")
-
-        ayon_server_url = config.GetConfigEntryWithDefault("AyonServerUrl", "")
-        ayon_api_key = config.GetConfigEntryWithDefault("AyonApiKey", "")
-        job_ayon_server_url = job.GetJobEnvironmentKeyValue("AYON_SERVER_URL")
-        job_ayon_api_key = job.GetJobEnvironmentKeyValue("AYON_API_KEY")
-
-        # API key submitted with job environment will always take priority
-        if job_ayon_api_key:
-            ayon_api_key = job_ayon_api_key
-
-        # Allow custom AYON API key per server URL if server URL is submitted
-        # along with the job. The custom API keys can be configured on the
-        # Deadline Repository AYON Plug-in settings, in the format of
-        # `SERVER:PORT@APIKEY` per line.
-        elif job_ayon_server_url and job_ayon_server_url != ayon_server_url:
-            api_key = get_ayon_api_key_from_additional_servers(
-                config, job_ayon_server_url)
-            if api_key:
-                ayon_api_key = api_key
-            else:
-                print(
-                    "AYON Server URL submitted with job "
-                    f"'{job_ayon_server_url}' has no API key defined "
-                    "in AYON Deadline plugin configuration,"
-                    " `Additional AYON Servers` section."
-                    " Use Deadline monitor to modify the values."
-                    "Falling back to `AYON API key` set in `AYON Credentials`"
-                    " section of AYON plugin configuration."
-                )
-            ayon_server_url = job_ayon_server_url
-
-        if not all([ayon_server_url, ayon_api_key]):
-            raise RuntimeError(
-                "Missing required values for server url and api key. "
-                "Please fill in AYON Deadline plugin or provide by "
-                "AYON_SERVER_URL and AYON_API_KEY"
-            )
+        ayon_server_url, ayon_api_key = handle_credentials(job)
 
         site_id = os.environ.get("AYON_SITE_ID")
         shared_env_group = None

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -716,16 +716,15 @@ def inject_render_job_id(deadlinePlugin):
     print(">>> Dependency IDs: {}".format(dependency_ids))
     render_job_ids = ",".join(dependency_ids)
 
-    deadlinePlugin.SetProcessEnvironmentVariable(
-        "RENDER_JOB_IDS", render_job_ids
-    )
     ayon_server_url, ayon_api_key = handle_credentials(job)
-    deadlinePlugin.SetProcessEnvironmentVariable(
-        "AYON_SERVER_URL", ayon_server_url
-    )
-    deadlinePlugin.SetProcessEnvironmentVariable(
-        "AYON_API_KEY", ayon_api_key
-    )
+
+    environment = {
+        "RENDER_JOB_IDS": render_job_ids,
+        "AYON_SERVER_URL": ayon_server_url,
+        "AYON_API_KEY": ayon_api_key
+    }
+    for env, val in environment.items():
+        job.SetJobEnvironmentKeyValue(env, val)
     print(">>> Injection end.")
 
 

--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -715,15 +715,17 @@ def inject_render_job_id(deadlinePlugin):
     dependency_ids = job.JobDependencyIDs
     print(">>> Dependency IDs: {}".format(dependency_ids))
     render_job_ids = ",".join(dependency_ids)
+    deadlinePlugin.SetProcessEnvironmentVariable(
+        "RENDER_JOB_IDS", render_job_ids
+    )
 
     ayon_server_url, ayon_api_key = handle_credentials(job)
 
-    environment = {
-        "RENDER_JOB_IDS": render_job_ids,
+    credentials = {
         "AYON_SERVER_URL": ayon_server_url,
         "AYON_API_KEY": ayon_api_key
     }
-    for env, val in environment.items():
+    for env, val in credentials.items():
         job.SetJobEnvironmentKeyValue(env, val)
     print(">>> Injection end.")
 


### PR DESCRIPTION
## Changelog Description
If `Additional AYON Servers` configuration was used, AYON_API_KEY weren't picked up for Publish job. This limited that functionality as it would be working only for same key values on all servers.

## Testing notes:
0. Redeploy `https://github.com/ynput/ayon-deadline/tree/develop/client/ayon_deadline/repository/custom/plugins` to `DL_REPO/custom/plugins`
1. enable `ayon+settings://deadline/publish/CollectAYONServerToFarmJob`
2. break AYON_SERVER_URL and AYON_API_KEY values in AYON Deadline plugin configuration
3. fill working combo to `Additional AYON Servers` in DL AYON plugin configuration
<img width="786" height="795" alt="image" src="https://github.com/user-attachments/assets/b1bdf04a-f233-45e1-8dcc-86e140ca1417" />

4. publish


Issue: YN-0013