### PR TITLE
Chore: Remove houdini version compatibility

### DIFF
--- a/package.py
+++ b/package.py
@@ -8,6 +8,4 @@ ayon_required_addons = {
     "core": ">1.0.9",
     "applications": ">=1.0.0",
 }
-ayon_compatible_addons = {
-    "houdini": ">0.6.3",
-}
+ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Revert houdini version compatibility added in https://github.com/ynput/ayon-deadline/pull/201 .

## Additional review information
Deadline is still compatible with older versions of houdini addon.

## Testing notes:
1. Use older houdini addon versions that what is defined in package.py .
2. Farm publishing should work just fine.