### PR TITLE
Deadline info: Recollect server info on farm

### DIFF
--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -270,19 +270,19 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         server_info: Dict[str, Any],
         local_settings: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[str, str]]:
-        server_name = server_info["name"]
+        selected_server_name = server_info["name"]
 
         require_authentication = server_info["require_authentication"]
         if require_authentication:
             if local_settings is None:
                 local_settings = self._get_local_settings()
 
-            for server_info in local_settings["local_settings"]:
-                if server_name != server_info["server_name"]:
+            for local_info in local_settings["local_settings"]:
+                if selected_server_name != local_info["server_name"]:
                     continue
 
-                if server_info["username"] and server_info["password"]:
-                    return server_info["username"], server_info["password"]
+                if local_info["username"] and local_info["password"]:
+                    return local_info["username"], local_info["password"]
 
         default_username = server_info["default_username"]
         default_password = server_info["default_password"]

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -16,6 +16,7 @@ TODOS:
 - Don't store deadline url, but use server name instead.
 
 """
+import os
 from typing import Optional, Tuple
 
 import pyblish.api
@@ -30,13 +31,14 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
     # Run before collect_render.
     order = pyblish.api.CollectorOrder + 0.225
     label = "Deadline Webservice from the Instance"
-    targets = ["local"]
+    targets = ["local", "deadline"]
 
     families = FARM_FAMILIES
 
     def process(self, instance):
-        if not instance.data.get("farm"):
-            self.log.debug("Should not be processed on farm, skipping.")
+        if (not instance.data.get("farm") and
+                not os.environ.get("HEADLESS_PUBLISH")):
+            self.log.debug("Should not be processed on local inst, skipping.")
             return
 
         # NOTE: Remove when nothing sets 'deadline' to 'None'

--- a/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py
@@ -36,9 +36,11 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
     families = FARM_FAMILIES
 
     def process(self, instance):
-        if (not instance.data.get("farm") and
-                not os.environ.get("HEADLESS_PUBLISH")):
-            self.log.debug("Should not be processed on local inst, skipping.")
+        if (
+            not instance.data.get("farm")
+            and not os.environ.get("HEADLESS_PUBLISH")
+        ):
+            self.log.debug("Should not be processed, skipping.")
             return
 
         # NOTE: Remove when nothing sets 'deadline' to 'None'

--- a/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_default_deadline_server.py
@@ -20,7 +20,7 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
     # Run before collect_deadline_server_instance.
     order = pyblish.api.CollectorOrder + 0.200
     label = "Default Deadline Webservice"
-    targets = ["local"]
+    targets = ["local", "deadline"]
 
     def process(self, context):
         deadline_addon = context.data["ayonAddonsManager"]["deadline"]

--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -29,7 +29,7 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.250
     label = "Collect Deadline User Credentials"
 
-    targets = ["local","deadline"]
+    targets = ["local", "deadline"]
 
     families = FARM_FAMILIES
 

--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -29,13 +29,14 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.250
     label = "Collect Deadline User Credentials"
 
-    targets = ["local"]
+    targets = ["local","deadline"]
 
     families = FARM_FAMILIES
 
     def process(self, instance):
-        if not instance.data.get("farm"):
-            self.log.debug("Should not be processed on farm, skipping.")
+        if (not instance.data.get("farm") and
+                not os.environ.get("HEADLESS_PUBLISH")):
+            self.log.debug("Should not be processed on local inst, skipping.")
             return
 
         collected_deadline_url = instance.data["deadline"]["url"]

--- a/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_user_credentials.py
@@ -34,9 +34,11 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
     families = FARM_FAMILIES
 
     def process(self, instance):
-        if (not instance.data.get("farm") and
-                not os.environ.get("HEADLESS_PUBLISH")):
-            self.log.debug("Should not be processed on local inst, skipping.")
+        if (
+            not instance.data.get("farm")
+            and not os.environ.get("HEADLESS_PUBLISH")
+        ):
+            self.log.debug("Should not be processed, skipping.")
             return
 
         collected_deadline_url = instance.data["deadline"]["url"]

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -410,11 +410,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             instance, render_job, instances, rootless_metadata_path
         )
 
-        # Inject deadline url to instances to query DL for job id for overrides
-        for inst in instances:
-            inst["deadline"] = deepcopy(instance.data["deadline"])
-            inst["deadline"].pop("job_info")
-
         # publish job file
         publish_job = {
             "folderPath": instance_skeleton_data["folderPath"],


### PR DESCRIPTION
## Changelog Description
Current Deadline implementation allows to setup multiple different IP/ports for Deadline server which could be used in different environment. (For example main DL server used in studio, another IP/port used for freelancers only).

This fixes an issue when freelancer was using secondary DL server configuration which was saved to metadata.json, which caused an issue during Publish in the studio (worker node picked this secondary IP from json file and this IP was used INSIDE of studio, where it is not accessible).


## Additional Details
Existing implementation was allowing to have multiple DL server (`production` vs `staging`, `maya` vs `nuke`). TD must set `main` server in `Project Settings`, BUT artists might choose to send job to different DL server (via Site Settings, or through dropdown in Publisher UI - possibly, not there yet). This selected server name was stored in `metadata.json` (which is used as a source for `Publish` job) to collect `url` (possibly default `auth`) for this particular DL server. 
(All this information is used in `ValidateExpectedFiles` which checks actual values of frame range which was used for `render` job. This frame range could be manually changed on DL and might be different from a frame range that was set during AYON submission and which was stored in `metadata.json`.)

This PR strips saving DL server name to `metadata.json` and forcing to look for default values in `Project Settings`. Which in original use case (2 physically different servers) will not work. (Artist sent job to `staging` DL, but in `Project Settings` it is set to use `production`.)

## Testing notes:
1. set multiple DL configuration in `ayon+settings://deadline`
<img width="976" height="638" alt="image" src="https://github.com/user-attachments/assets/eba82132-8d52-4682-8bb7-55f80d0415ee" />
(I enabled also authentication for my working DL configuration, port 8082. - https://help.ayon.app/articles/5372986-configure-deadline-addon#wc4i7beia26 )

2. select NOT working DL in `Project Settings` (this would limit artist from finishing Publish in Publisher UI in DCC, as it would mimic that artist doesn't have access to this IP)

3. select working DL server in `Project Settings > Site Settings` `ayon+settings://deadline?project=ayon_dev&site=XXX`
<img width="1739" height="377" alt="image" src="https://github.com/user-attachments/assets/187e46e6-5d7f-47e1-8e99-7e3fa9e54857" /> (this mimics that artists overrides and choses valid IP for them)

4. publish to DL, it shouldnt fail in Publisher UI

5. without any change this will eventually fail during `Publish` job - as DL worker looks on value in `Project Settings` where it is still non working one

7. update selected DL server in  `Project Settings` - currently running and failing Publish job should finish fine (as worker nodes now picks up updated value from Settings)
