### PR TITLE
Fix shadowing of server_info with local settings

### DIFF
--- a/client/ayon_deadline/addon.py
+++ b/client/ayon_deadline/addon.py
@@ -270,19 +270,19 @@ class DeadlineAddon(AYONAddon, IPluginPaths):
         server_info: Dict[str, Any],
         local_settings: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[str, str]]:
-        server_name = server_info["name"]
+        selected_server_name = server_info["name"]
 
         require_authentication = server_info["require_authentication"]
         if require_authentication:
             if local_settings is None:
                 local_settings = self._get_local_settings()
 
-            for server_info in local_settings["local_settings"]:
-                if server_name != server_info["server_name"]:
+            for local_info in local_settings["local_settings"]:
+                if selected_server_name != local_info["server_name"]:
                     continue
 
-                if server_info["username"] and server_info["password"]:
-                    return server_info["username"], server_info["password"]
+                if local_info["username"] and local_info["password"]:
+                    return local_info["username"], local_info["password"]
 
         default_username = server_info["default_username"]
         default_password = server_info["default_password"]


### PR DESCRIPTION
## Changelog Description
This caused issue if no credentials were provided.

## Additional review information
It raised KeyError on `default_username` as local server_info overshadowing main one doesn't have any `default_username`.

## Testing notes:
1. Set `ayon+settings://deadline/deadline_urls` requiring authentication
2. enable authenticcation on DL
https://help.ayon.app/articles/5372986-configure-deadline-addon#wc4i7beia26
3. provide no user credentials in `Studio Settings > Site Settings`
4. submission to DL shouldnt fail