### PR TITLE
Collect Job Info: Fix get publish use custom frames value logic

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -461,7 +461,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
     def _get_publish_use_custom_frames_value(cls, instance_data):
         return (
             instance_data.get("publish_attributes", {})
-                         .get("CollectJobInfo")
+                         .get("CollectJobInfo", {})
                          .get("use_custom_frames")
         )
 


### PR DESCRIPTION
## Changelog Description

Fix getting value from instance data if `publish_attributes` did not exist or pre-existed but did not yet have any value for `CollectJobInfo` plug-in.

## Additional review information

Avoids errors like this in Fusion:
```python
Failed to get attribute definitions from plugin 'CollectJobInfo'.
Traceback (most recent call last):
  File "F:\dev\ayon-core\client\ayon_core\pipeline\create\context.py", line 2345, in _bulk_add_instances_finished
    attr_defs = plugin.get_attr_defs_for_instance(
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 266, in get_attr_defs_for_instance
    cls._get_publish_use_custom_frames_value(instance.data) or "none"
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 465, in _get_publish_use_custom_frames_value
    instance_data.get("publish_attributes", {})
```
and
```python
Traceback (most recent call last):
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2502101448_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 68, in process
    self._handle_custom_frames(attr_values, job_info)
  File "F:\dev\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 160, in _handle_custom_frames
    attr_values["use_custom_frames"]
KeyError: 'use_custom_frames'
```

Avoids errors like this in Houdini:
```python
Failed to get attribute definitions from plugin 'CollectJobInfo'.
Traceback (most recent call last):
  File "E:\Ynput\ayon-core\client\ayon_core\pipeline\create\context.py", line 2435, in _bulk_add_instances_finished
    attr_defs = plugin.get_attr_defs_for_instance(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Ynput\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 264, in get_attr_defs_for_instance
    cls._get_publish_use_custom_frames_value(instance.data) or "none"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Ynput\ayon-deadline\client\ayon_deadline\plugins\publish\global\collect_jobinfo.py", line 465, in _get_publish_use_custom_frames_value
    .get("use_custom_frames")
     ^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

Came up internally here: https://discord.com/channels/517362899170230292/1136202513402581006/1432831619579904060

## Testing notes:

1. Submitting to Deadline from variety of DCCs should work again.
