### PR TITLE
Fix: Use of settings variant for `Selected Deadline server name` dropdown

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -17,12 +17,13 @@ from .publish_plugins import (
 
 async def defined_deadline_ws_name_enum_resolver(
     addon: "BaseServerAddon",
+    settings_variant: str = None,
 ) -> list[str]:
     """Provides list of names of configured Deadline webservice urls."""
     if addon is None:
         return []
 
-    settings = await addon.get_studio_settings()
+    settings = await addon.get_studio_settings(variant=settings_variant)
 
     ws_server_name = []
     for deadline_url_item in settings.deadline_urls:


### PR DESCRIPTION
## Changelog Description
Dropdown for Deadline server names was only looking into `Production` bundle even if it was present in `Dev` or `Staging` bundles.



## Testing notes:
1. configure different names of Deadline servers in Studio settings for different variants
2. check that `Project Settings` dropdown uses this values 
<img width="1184" height="167" alt="image" src="https://github.com/user-attachments/assets/583812ca-46dc-4939-afa5-1f8aee3f8445" />
