### PR TITLE
Collect Job Info: Do not fail on `_handle_custom_frames` if instance does not have Use Custom Frames attribute set

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 from datetime import datetime
+from typing import Optional
 
 import pyblish.api
 from ayon_core.lib import (
@@ -157,7 +158,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         job_info.Frames = None
         job_info.reuse_last_version = False
         use_custom_frames = self._is_custom_frames_used(
-            attr_values["use_custom_frames"]
+            attr_values.get("use_custom_frames")
         )
         if use_custom_frames:
             if not attr_values["frames"]:
@@ -454,11 +455,14 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             instance.set_publish_plugin_attr_defs(cls.__name__, new_attrs)
 
     @classmethod
-    def _is_custom_frames_used(cls, value):
+    def _is_custom_frames_used(cls, value) -> bool:
         return value in ["custom_only", "reuse_last_version"]
 
     @classmethod
-    def _get_publish_use_custom_frames_value(cls, instance_data):
+    def _get_publish_use_custom_frames_value(
+        cls,
+        instance_data
+    ) -> Optional[str]:
         return (
             instance_data.get("publish_attributes", {})
                          .get("CollectJobInfo", {})


### PR DESCRIPTION
## Changelog Description

Do not fail on `_handle_custom_frames` if instance does not have Use Custom Frames attribute show and hence it's not set in `attr_values`

## Additional review information

May avoid:
<img width="425" height="95" alt="image" src="https://github.com/user-attachments/assets/8f9d8fb0-a47a-45ae-8df5-1130d5c3d845" />

Came up internally here: https://discord.com/channels/517362899170230292/1435952930636435486

## Testing notes:

1. Publish without any exposed overrides from a DCC (then it will also not show "Use Custom Frames" as described in https://github.com/ynput/ayon-deadline/issues/209 and hence it failed)
