### PR TITLE
Avoid adding baking jobs id's to jobDependencies list.

### DIFF
--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -102,18 +102,18 @@ class NukeSubmitDeadline(
             instance.data["outputDir"] = os.path.dirname(
                 render_path).replace("\\", "/")
 
+        render_job_data = instance.data.get("deadlineSubmissionJob", {})
+        render_job_id = render_job_data.get("_id")
+
         if instance.data.get("bakingNukeScripts"):
             for baking_script in instance.data["bakingNukeScripts"]:
                 self.job_info = copy.deepcopy(self.job_info)
                 self.job_info.JobType = "Normal"
 
-                response_data = instance.data.get("deadlineSubmissionJob", {})
-                response_id = response_data.get("_id")
                 # frames_farm instance doesn't have render submission
-                if response_id:
-                    self.job_info.BatchName = response_data["Props"]["Batch"]
-                    if response_id not in instance.data.get("bakingSubmissionJobs", []):
-                        self.job_info.JobDependencies.append(response_id)
+                if render_job_id:
+                    self.job_info.BatchName = render_job_data["Props"]["Batch"]
+                    self.job_info.JobDependencies.append(render_job_id)
 
                 render_path = baking_script["bakeRenderPath"]
                 scene_path = baking_script["bakeScriptPath"]


### PR DESCRIPTION
## Changelog Description

This PR fixes issue #215. 

Baking jobs id's were being added to `job.JobDependencies` list, therefore making them dependent on the previous one (this dependencies list would increase if more baking profiles are defined)


## Additional review information
Before adding any id to `job.JobDependencies` list, we first check if it's the id of a baking job. If so, id it's not added to that list. 

## Testing notes:

### Test with farm rendering

1. In Nuke settings, set more than one baking stream (`ExtractReviewIntermediates`).
2. Launch Nuke and submit to the farm.
3. Check second baking job, it shouldn't have a dependency on the first one (it should on the rendering job).

### Test with use existing frames - farm

- In Nuke settings, set more than one baking stream (`ExtractReviewIntermediates`).
- Launch Nuke and submit to the farm.
- Check second baking job, it shouldn't have a dependency on the first one.

Resolves https://github.com/ynput/ayon-deadline/issues/215