### PR TITLE
Support Local Export and Farm Rendering

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -116,7 +116,17 @@ class AbstractSubmitDeadline(
                 instance,
                 self.job_info
             )
-        self.plugin_info = self.get_plugin_info()
+
+        # If the render file export happens locally,
+        # get the plugin info directly as a render job type.
+        creator_attribute = instance.data.get("creator_attributes")
+        if (
+            creator_attribute.get("render_target")
+            == "local_export_farm_render"
+        ):
+            self.plugin_info = self.get_plugin_info(job_type="render")
+        else:
+            self.plugin_info = self.get_plugin_info()
 
         self.aux_files = self.get_aux_files()
 

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -159,6 +159,14 @@ class HoudiniSubmitDeadline(
         if dependency_job_ids:
             is_export_job = False
 
+        # If the render file export happens locally,
+        # override 'split_render_job' and 'is_export_job'
+        # to get the correct render plugin later on
+        creator_attr = instance.data["creator_attributes"]
+        if creator_attr.get("render_target") == "local_export_farm_render":
+            split_render_job = True
+            is_export_job = False
+
         job_type = "[RENDER]"
         if split_render_job and not is_export_job:
             families = self._get_families(instance)


### PR DESCRIPTION
## Changelog Description
Support local render file export and farm rendering.

## Additional review information
Prepare ayon-deadline to submit only the render job in case the render target `local_export_farm_render` was set as a render target, and therefore the render file was already extracted locally during the publish process.

This PR only works in combination with the corresponding PR in ayon-houdini:
https://github.com/ynput/ayon-houdini/pull/329

## Related Issue and forum post
Old Ayon-Houdini issue:
https://github.com/ynput/ayon-houdini/issues/6
See the discussion in the forum for further information:
https://community.ynput.io/t/houdini-usd-render-local-export-husk-farm-rendering/2924

## Testing notes:
1. Start Houdini and create a "USD Render" product.
2. Change "Render target" to "Local Export & Farm Rendering"
3. Publish; now the export should happen locally and just the render job will appear in Deadline.
