### PR TITLE
Vray: Enable vray frame buffer in 3dsmax farm submission

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -146,6 +146,11 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if renderer == "Redshift_Renderer":
             plugin_data["redshift_SeparateAovFiles"] = instance.data.get(
                 "separateAovFiles")
+
+        elif renderer.startswith("V_Ray_"):
+            # enable this so that V-Ray frame buffer shows up
+            plugin_data["ShowFrameBuffer"] = True
+
         if instance.data["cameras"]:
             camera = instance.data["cameras"][0]
             plugin_info["Camera0"] = camera


### PR DESCRIPTION
## Changelog Description
This PR is to make sure Vray-specific attribute frame buffer is True when users set Vray as renderers, by doing this it would ensure the frames are rendered in vray-mode instead of native max mode. 
Resolve https://github.com/ynput/ayon-3dsmax/issues/81

## Additional review information
Make sure frame buffer enabled in render setting and let Vray do the work for you.
Tested with https://github.com/ynput/ayon-3dsmax/pull/80 with/without save alpha option

## Testing notes:
1. Create Render Instance 
2. Publish
