### PR TITLE
GlobalJobPreLoad: Do not try to load json if extract environments failed

### DIFF
--- a/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -684,7 +684,7 @@ def _extract_environments(
     )
     if _process_exitcode != 0:
         raise RuntimeError(
-            "Executing AYON process to extract environments"
+            "AYON process to extract environments"
             f" exited with error code: {_process_exitcode}"
         )
 


### PR DESCRIPTION
## Changelog Description

In GlobalJobPreLoad do not try to still continue parsing a potentially non-existing or empty .json file if extract enviroments failed.

## Additional review information

Avoids e.g. an invalid API key failure to login to continue still trying to read for a JSON file:
```
2026-01-09 22:58:27:  0: STDOUT: >>> Reached main entry point (0.84s).
2026-01-09 22:58:27:  0: STDOUT: *** Using API key from environment variable to connect
2026-01-09 22:58:27:  0: STDOUT: !!! Got invalid credentials.
2026-01-09 22:58:27:  0: STDOUT: Invalid API key for 'http://127.0.0.1:5000'.
2026-01-09 22:58:27:  0: STDOUT: !!! Please use 'AYON_SERVER_URL' and 'AYON_API_KEY' environment variables to specify valid server url and api key for headless mode.
2026-01-09 22:58:27:  0: PYTHON: Creating env var file C:\Users\User\AppData\Local\Temp\20260109215826378699_532535f4-eda6-11f0-9970-477a819498f5.json
2026-01-09 22:58:27:  0: PYTHON: >>> Loading file 'C:\Users\User\AppData\Local\Temp\20260109215826378699_532535f4-eda6-11f0-9970-477a819498f5.json' ...
2026-01-09 22:58:27:  0: PYTHON: Traceback (most recent call last):
2026-01-09 22:58:27:  0: PYTHON:   File "C:\ProgramData\Thinkbox\Deadline10\workers\Roy\plugins\696179f9552d2214a5d6c759\GlobalJobPreLoad.py", line 518, in inject_ayon_environment
2026-01-09 22:58:27:  0: PYTHON:     contents = json.load(fp)
2026-01-09 22:58:27:  0: PYTHON:   File "C:\Program Files\Thinkbox\Deadline10\bin\python3\lib\json\__init__.py", line 293, in load
2026-01-09 22:58:27:  0: PYTHON:     return loads(fp.read(),
2026-01-09 22:58:27:  0: PYTHON:   File "C:\Program Files\Thinkbox\Deadline10\bin\python3\lib\json\__init__.py", line 346, in loads
2026-01-09 22:58:27:  0: PYTHON:     return _default_decoder.decode(s)
2026-01-09 22:58:27:  0: PYTHON:   File "C:\Program Files\Thinkbox\Deadline10\bin\python3\lib\json\decoder.py", line 337, in decode
2026-01-09 22:58:27:  0: PYTHON:     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
2026-01-09 22:58:27:  0: PYTHON:   File "C:\Program Files\Thinkbox\Deadline10\bin\python3\lib\json\decoder.py", line 355, in raw_decode
2026-01-09 22:58:27:  0: PYTHON:     raise JSONDecodeError("Expecting value", s, err.value) from None
```

Instead fail earlier:
```
2026-01-09 23:21:59:  0: STDOUT: >>> Reached main entry point (0.13s).
2026-01-09 23:21:59:  0: STDOUT: *** Using API key from environment variable to connect
2026-01-09 23:21:59:  0: STDOUT: !!! Got invalid credentials.
2026-01-09 23:21:59:  0: STDOUT: Invalid API key for 'http://127.0.0.1:5000'.
2026-01-09 23:21:59:  0: STDOUT: !!! Please use 'AYON_SERVER_URL' and 'AYON_API_KEY' environment variables to specify valid server url and api key for headless mode.
2026-01-09 23:21:59:  0: PYTHON: Traceback (most recent call last):
2026-01-09 23:21:59:  0: PYTHON:   File "C:\ProgramData\Thinkbox\Deadline10\workers\Roy\plugins\69617f74162b566cbc218af5\GlobalJobPreLoad.py", line 498, in inject_ayon_environment
2026-01-09 23:21:59:  0: PYTHON:     _extract_environments(
2026-01-09 23:21:59:  0: PYTHON:   File "C:\ProgramData\Thinkbox\Deadline10\workers\Roy\plugins\69617f74162b566cbc218af5\GlobalJobPreLoad.py", line 686, in _extract_environments
2026-01-09 23:21:59:  0: PYTHON:     raise RuntimeError(
2026-01-09 23:21:59:  0: PYTHON: RuntimeError: AYON process to extract environments exited with error code: 1
2026-01-09 23:21:59:  0: PYTHON: !!! Injection failed.
```

## Testing notes:

1. Publish and render on farm should work
2. Extra care here should be taken with the case where multiple workers share the same `AYON_SITE_ID`. Technically the `extract_environments` call could be triggered, and fail on one machine but succeed on another... and then if continuing the file could suddenly still exist. However, it could still be half-written at that point in time. So I think it should still fail. @kalisp thoughts?