### PR TITLE
Max: Use Scene workfile for multicamera farm submission

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -13,9 +13,6 @@ from ayon_max.api.lib import (
 )
 from ayon_max.api.lib_rendersettings import RenderSettings
 from ayon_deadline import abstract_submit_deadline
-from ayon_deadline.abstract_submit_deadline import (
-    replace_with_published_scene_path
-)
 
 
 @dataclass

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -270,9 +270,10 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     def from_published_scene(self, replace_in_path=True):
         """Check and use scene workfile for rendering only when multi-camera
         farm submission is enabled.
-        
+
         When rendering multi-camera scenes we can't render published workfiles
-        because X - so we require the work area workfile to be used to support Y.
+        because X - so we require the work area workfile to be used to
+        support Y.
 
         Args:
             replace_in_path (bool, optional): Whether to replace the scene path

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -271,6 +271,16 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         return job_info_list, plugin_info_list
 
     def from_published_scene(self, replace_in_path=True):
+        """Check and use scene workfile for rendering only when multi-camera
+        farm submission is enabled.
+
+        Args:
+            replace_in_path (bool, optional): Whether to replace the scene path
+                with the published scene path. Defaults to True.
+
+        Returns:
+            str: Published scene path.
+        """
         instance = self._instance
         if instance.data.get("multiCamera"):
             self.log.warning(
@@ -279,8 +289,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             )
             replace_in_path = False
 
-        return replace_with_published_scene_path(
-            instance, replace_in_path)
+        return super().from_published_scene(replace_in_path=replace_in_path)
 
     @staticmethod
     def _collect_render_output(renderer, dir, plugin_data):

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -270,6 +270,9 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     def from_published_scene(self, replace_in_path=True):
         """Check and use scene workfile for rendering only when multi-camera
         farm submission is enabled.
+        
+        When rendering multi-camera scenes we can't render published workfiles
+        because X - so we require the work area workfile to be used to support Y.
 
         Args:
             replace_in_path (bool, optional): Whether to replace the scene path

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -13,6 +13,9 @@ from ayon_max.api.lib import (
 )
 from ayon_max.api.lib_rendersettings import RenderSettings
 from ayon_deadline import abstract_submit_deadline
+from ayon_deadline.abstract_submit_deadline import (
+    replace_with_published_scene_path
+)
 
 
 @dataclass
@@ -267,20 +270,17 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
         return job_info_list, plugin_info_list
 
-    @staticmethod
-    def _is_unsupported_renderer_for_published_scene(renderer):
-        """Check if renderer doesn't support published scene files."""
-        unsupported_renderers = (
-            "Redshift_Renderer",
-        )
-        unsupported_prefixes = (
-            "Arnold",
-            "V_Ray_",
-        )
-        return (
-            renderer in unsupported_renderers
-            or renderer.startswith(unsupported_prefixes)
-        )
+    def from_published_scene(self, replace_in_path=True):
+        instance = self._instance
+        if instance.data.get("multiCamera"):
+            self.log.warning(
+                "Use published workfile for rendering "
+                "not supported for multi-camera."
+            )
+            replace_in_path = False
+
+        return replace_with_published_scene_path(
+            instance, replace_in_path)
 
     @staticmethod
     def _collect_render_output(renderer, dir, plugin_data):

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -436,7 +436,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         render_dir = Path(os.path.dirname(first_file))
         render_dir.mkdir(parents=True, exist_ok=True)
         script_path = render_dir / "pre_load_max_script.ms"
-        script_path = str(script_path.resolve())
+        script_path = os.path.normpath(script_path.as_posix())
 
         try:
             with open(script_path, "w") as script_file:

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -436,12 +436,13 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         render_dir = Path(os.path.dirname(first_file))
         render_dir.mkdir(parents=True, exist_ok=True)
         script_path = render_dir / "pre_load_max_script.ms"
+        script_path = str(script_path.resolve())
 
         try:
             with open(script_path, "w") as script_file:
                 script_file.write(max_script)
             print(f"Temporary pre-load maxscript created at: {script_path}")
-            return str(script_path)
+            return script_path
 
         except Exception as e:
             raise RuntimeError(f"Error creating maxscript file: {str(e)}")

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -85,7 +85,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if not files:
             raise KnownPublishError("No Render Elements found!")
         first_file = next(self._iter_expected_files(files))
-        output_dir = os.path.dirname(first_file)
+        output_dir = Path(first_file).parent.as_posix()
         instance.data["outputDir"] = output_dir
 
         filename = os.path.basename(filepath)

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -50,6 +50,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if instance.data.get("multiCamera"):
             job_info.OutputDirectory.clear()
             job_info.OutputFilename.clear()
+            job_info.AssetDependency.clear()
 
         return job_info
 


### PR DESCRIPTION
## Changelog Description
This PR is to introduce the condition of using scene workfile only when the multi-camera farm submission enabled in 3dsmax.

## Additional review information
Bug found in https://github.com/ynput/ayon-3dsmax/pull/99

## Testing notes:
1. Create Render with farm rendering as option
2. Publish