### PR TITLE
Max: Remove render job environment which blocks Max farm rendering 

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -267,26 +267,20 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
         return job_info_list, plugin_info_list
 
-    def from_published_scene(self, replace_in_path=True):
-        """Check and use scene workfile for rendering only when multi-camera
-        farm submission is enabled.
-
-        Args:
-            replace_in_path (bool, optional): Whether to replace the scene path
-                with the published scene path. Defaults to True.
-
-        Returns:
-            str: Published scene path.
-        """
-        instance = self._instance
-        if instance.data.get("multiCamera"):
-            self.log.warning(
-                "Use published workfile for rendering "
-                "not supported for multi-camera."
-            )
-            replace_in_path = False
-
-        return super().from_published_scene(replace_in_path=replace_in_path)
+    @staticmethod
+    def _is_unsupported_renderer_for_published_scene(renderer):
+        """Check if renderer doesn't support published scene files."""
+        unsupported_renderers = (
+            "Redshift_Renderer",
+        )
+        unsupported_prefixes = (
+            "Arnold",
+            "V_Ray_",
+        )
+        return (
+            renderer in unsupported_renderers
+            or renderer.startswith(unsupported_prefixes)
+        )
 
     @staticmethod
     def _collect_render_output(renderer, dir, plugin_data):


### PR DESCRIPTION
## Changelog Description
This PR is to avoid adding render job variable so that 3dmax do farm submission successfully with render presets
Resolve https://github.com/ynput/ayon-3dsmax/issues/93

## Additional review information
We need to discuss if there is any better solution 

## Testing notes:
1. Publish Render from 3dsmax
2. Should be working