### PR TITLE
Max: Submission won't be triggered when local rendering enabled.

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -66,6 +66,14 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
         return plugin_payload
 
+    def process(self, instance):
+        if not instance.data["farm"]:
+            self.log.debug("Render on farm is disabled. "
+                           "Skipping deadline submission.")
+            return
+
+        super().process(instance)
+
     def process_submission(self):
 
         instance = self._instance


### PR DESCRIPTION
## Changelog Description
This PR is to make sure farm submission won't be triggered when users choose using local rendering option in 3dsmax.

## Additional review information
Related to https://github.com/ynput/ayon-3dsmax/pull/99

## Testing notes:
1. Create Render Instance
2. Publish
