### PR TITLE
CollectJobInfo: filter profiles by product_base_type

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -53,7 +53,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             self.log.debug("Should not be processed on farm, skipping.")
             return
 
-        attr_values = self._get_jobinfo_defaults(instance)
+        attr_values = self._get_profile_for_instance(instance)
         if not attr_values:
             raise PublishError(
                 "No profile selected for defaults. Ask Admin to "
@@ -234,6 +234,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
 
         task_name = instance["task"]
         folder_path = instance["folderPath"]
+        product_base_type = instance.data.get("productBaseType")
         task_entity = create_context.get_task_entity(folder_path, task_name)
 
         task_name = task_type = None
@@ -246,6 +247,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 "host_names": host_name,
                 "task_types": task_type,
                 "task_names": task_name,
+                "product_base_types": product_base_type,
             }
         )
         if not profile:
@@ -468,14 +470,15 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                          .get("use_custom_frames")
         )
 
-    def _get_jobinfo_defaults(self, instance):
-        """Queries project setting for profile with default values
+    def _get_profile_for_instance(self, instance):
+        """Returns the profile to use for the given instance.
 
         Args:
             instance (pyblish.api.Instance): Source instance.
 
         Returns:
             (dict)
+
         """
         context_data = instance.context.data
         host_name = context_data["hostName"]
@@ -485,6 +488,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         if task_entity:
             task_name = task_entity["name"]
             task_type = task_entity["taskType"]
+        product_base_type = instance.data.get("productBaseType")
 
         profile = filter_profiles(
             self.profiles,
@@ -492,7 +496,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 "host_names": host_name,
                 "task_types": task_type,
                 "task_names": task_name,
-                # "product_type": product_type
+                "product_base_types": product_base_type,
             }
         )
         return profile or {}

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -235,6 +235,8 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         task_name = instance["task"]
         folder_path = instance["folderPath"]
         product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         task_entity = create_context.get_task_entity(folder_path, task_name)
 
         task_name = task_type = None
@@ -489,6 +491,9 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
             task_name = task_entity["name"]
             task_type = task_entity["taskType"]
         product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+        
 
         profile = filter_profiles(
             self.profiles,

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -493,7 +493,6 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
         product_base_type = instance.data.get("productBaseType")
         if not product_base_type:
             product_base_type = instance.data["productType"]
-        
 
         profile = filter_profiles(
             self.profiles,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -4,10 +4,7 @@ from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
     ensure_unique_names,
-)
-from ayon_server.settings.enum import (
     task_types_enum,
-    product_types_enum,
 )
 
 
@@ -74,7 +71,6 @@ class CollectJobInfoItem(BaseSettingsModel):
     product_base_types: list[str] = SettingsField(
         default_factory=list,
         title="Product base types",
-        enum_resolver=product_types_enum,
         description=(
             "Apply this profile only for products "
             "with these productBaseTypes."

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -4,7 +4,10 @@ from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
     ensure_unique_names,
+)
+from ayon_server.settings.enum import (
     task_types_enum,
+    product_types_enum,
 )
 
 
@@ -57,16 +60,25 @@ class CollectJobInfoItem(BaseSettingsModel):
     _layout = "expanded"
     host_names: list[str] = SettingsField(
         default_factory=list,
-        title="Host names"
+        title="Host names",
     )
     task_types: list[str] = SettingsField(
         default_factory=list,
         title="Task types",
-        enum_resolver=task_types_enum
+        enum_resolver=task_types_enum,
     )
     task_names: list[str] = SettingsField(
         default_factory=list,
-        title="Task names"
+        title="Task names",
+    )
+    product_base_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Product base types",
+        enum_resolver=product_types_enum,
+        description=(
+            "Apply this profile only for products "
+            "with these productBaseTypes."
+        ),
     )
 
     #########################################
@@ -468,6 +480,7 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
           ],
           "task_names": [],
           "task_types": [],
+          "product_base_types": [],
           "limit_groups": [],
           "machine_list": [],
           "primary_pool": "",


### PR DESCRIPTION
## Changelog Description
Allows matching deadline profiles based on `productBaseType`

## Additional review information
This is an example config I was using, which sets different priorities and limits based on `productBaseTypes`
```json
{
  "publish": {
    "CollectJobInfo": {
      "profiles": [
        {
          "chunk_size": 1,
          "priority": 40
        },
        {
          "chunk_size": 10,
          "group": "medium",
          "host_names": ["nuke"],
          "overrides": ["group", "chunk_size", "priority"],
          "priority": 70
        },
        {
          "chunk_size": 1,
          "group": "medium",
          "host_names": ["houdini"],
          "overrides": ["group", "chunk_size", "priority"],
          "priority": 50
        },
        {
          "chunk_size": 1,
          "group": "medium",
          "host_names": ["houdini"],
          "overrides": ["group", "chunk_size", "priority"],
          "priority": 55,
          "product_base_types": ["render"]
        },
        {
          "chunk_size": 1,
          "group": "medium",
          "host_names": ["houdini"],
          "limit_groups": ["pointcache"],
          "overrides": ["group", "chunk_size", "priority"],
          "priority": 60,
          "product_base_types": ["pointcache"]
        }
      ]
    },
  "deadline_urls": [
    {
      "name": "default",
      "value": "http://localhost:8081/",
      "not_verify_ssl": false,
      "default_password": "",
      "default_username": "",
      "require_authentication": false
    }
  ]
}
```

expected result when submitting a `pointcache`, `render` and `model` (using the default "houdini" profile) to deadline
<img width="835" height="162" alt="image" src="https://github.com/user-attachments/assets/291cd68a-7352-4087-9e77-b3ad0c9e330d" />

addon settings with the new filter option
<img width="963" height="566" alt="image" src="https://github.com/user-attachments/assets/ea24eb5f-1840-437e-bfd9-f85d9b8957dc" />


## Testing notes:
1. add one or more profiles using `productBaseTypes` as one of their match-parameters
2. submit jobs to deadline and confirm the settings from the profile are applied

---

Related to [internal private discussion on Discord](https://discord.com/channels/517362899170230292/1471617658578276488).
