### PR TITLE
Options for use local temporary directory for Pre-load Maxscript

### DIFF
--- a/client/ayon_deadline/plugins/publish/global/collect_temp_file_cleanup.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_temp_file_cleanup.py
@@ -41,3 +41,30 @@ class CollectSceneRenderCleanUp(pyblish.api.InstancePlugin):
         self.log.debug(f"Files to clean up: {files}")
         instance.context.data["cleanupEmptyDirs"].extend(staging_dirs)
         self.log.debug(f"Staging dirs to clean up: {staging_dirs}")
+
+
+class CollectTempFileCleanUp(pyblish.api.InstancePlugin):
+    """Collect files and directories to be cleaned up"""
+
+    order = pyblish.api.CollectorOrder - 0.2
+    label = "Collect Temp File Clean Up"
+    targets = ["farm"]
+
+    def process(self, instance):
+        env_temp_dir = os.getenv("AYON_TMPDIR")
+        if not env_temp_dir:
+            return
+        for tmp_file in os.listdir(env_temp_dir):
+            file_path = os.path.join(env_temp_dir, tmp_file)
+            if os.path.isfile(file_path):
+                instance.context.data["cleanupFullPaths"].append(file_path)
+            elif os.path.isdir(file_path):
+                for tmp_script in os.listdir(file_path):
+                    script_path = os.path.join(file_path, tmp_script)
+                    if os.path.isfile(script_path):
+                        instance.context.data["cleanupFullPaths"].append(script_path)
+                instance.context.data["cleanupEmptyDirs"].append(file_path)
+        self.log.debug(
+            "Temp files to clean up: "
+            f"{instance.context.data['cleanupEmptyDirs']}"
+        )

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -3,7 +3,6 @@ import copy
 from dataclasses import dataclass, field, asdict
 import uuid
 
-from ayon_core.lib import BoolDef
 from ayon_core.pipeline import (
     AYONPyblishPluginMixin,
     tempdir
@@ -36,16 +35,6 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
     # Settings
     use_local_temp = True
-
-    @classmethod
-    def get_attribute_defs(cls):
-        return [
-            BoolDef(
-                "use_local_temp",
-                label="Use Local Temp",
-                default=cls.use_local_temp,
-            ),
-        ]
 
     def get_job_info(self, job_info=None):
 

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -1,7 +1,6 @@
 import os
 import copy
 from dataclasses import dataclass, field, asdict
-import uuid
 
 from ayon_core.pipeline import (
     AYONPyblishPluginMixin,
@@ -32,9 +31,6 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     families = ["maxrender"]
     targets = ["local"]
     settings_category = "deadline"
-
-    # Settings
-    use_local_temp = True
 
     def get_job_info(self, job_info=None):
 
@@ -321,13 +317,7 @@ def tmp_pre_load_max_script(instance, original_workfile, publish_workfile):
     Returns:
         str: Maxscript code as a string.
     """
-    use_local_temp = instance.data.get("use_local_temp", True)
-    temp_dir = tempdir.get_temp_dir(
-        instance.context.data["projectName"],
-        use_local_temp=use_local_temp
-    )
-    if use_local_temp:
-        temp_dir = os.path.join(temp_dir, publish_workfile)
+    temp_dir = tempdir.get_temp_dir(instance.context.data["projectName"])
 
     max_script = f"""
 fn PublishWorkfileRenderOutput =
@@ -409,7 +399,7 @@ renderOutputPublish = PublishWorkfileRenderOutput()
 """  # noqa: E501
 
     script_path = os.path.join(
-        temp_dir, f"pre_load_max_script_{uuid.uuid4().hex}.ms"
+        temp_dir, "pre_load_max_script.ms"
     )
 
     try:

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -398,9 +398,7 @@ renderOutputPublish = PublishWorkfileRenderOutput()
 
 """  # noqa: E501
 
-    script_path = os.path.join(
-        temp_dir, "pre_load_max_script.ms"
-    )
+    script_path = os.path.join(temp_dir, "pre_load_max_script.ms")
 
     try:
         with open(script_path, "w") as script_file:

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -2,6 +2,7 @@ import os
 import copy
 from dataclasses import dataclass, field, asdict
 
+from ayon_core.lib import BoolDef
 from ayon_core.pipeline import (
     AYONPyblishPluginMixin,
     tempdir
@@ -31,6 +32,19 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     families = ["maxrender"]
     targets = ["local"]
     settings_category = "deadline"
+
+    # Settings
+    use_local_temp = True
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            BoolDef(
+                "use_local_temp",
+                label="Use Local Temp",
+                default=cls.use_local_temp,
+            ),
+        ]
 
     def get_job_info(self, job_info=None):
 
@@ -317,9 +331,13 @@ def tmp_pre_load_max_script(instance, original_workfile, publish_workfile):
     Returns:
         str: Maxscript code as a string.
     """
+    use_local_temp = instance.data.get("use_local_temp", True)
     temp_dir = tempdir.get_temp_dir(
         instance.context.data["projectName"],
-        use_local_temp=True)
+        use_local_temp=use_local_temp
+    )
+    if use_local_temp:
+        temp_dir = os.path.join(temp_dir, publish_workfile)
 
     max_script = f"""
 fn PublishWorkfileRenderOutput =

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -1,6 +1,7 @@
 import os
 import copy
 from dataclasses import dataclass, field, asdict
+import uuid
 
 from ayon_core.lib import BoolDef
 from ayon_core.pipeline import (
@@ -418,7 +419,9 @@ renderOutputPublish = PublishWorkfileRenderOutput()
 
 """  # noqa: E501
 
-    script_path = os.path.join(temp_dir, "pre_load_max_script.ms")
+    script_path = os.path.join(
+        temp_dir, f"pre_load_max_script_{uuid.uuid4().hex}.ms"
+    )
 
     try:
         with open(script_path, "w") as script_file:

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -234,19 +234,6 @@ class MayaSubmitDeadlineModel(BaseSettingsModel):
         return value
 
 
-class MaxSubmitDeadlineModel(BaseSettingsModel):
-    """3ds Max-specific settings"""
-    use_local_temp: bool = SettingsField(
-        True,
-        title="Use local temp directory",
-        description=(
-            "Use local temp directory on render node for storing temporary "
-            "files related to the submission. Temporary files are deleted "
-            "after the job is finished."
-        )
-    )
-
-
 def fusion_deadline_plugin_enum():
     """Return a list of value/label dicts for the enumerator.
 
@@ -410,9 +397,6 @@ class PublishPluginsModel(BaseSettingsModel):
     MayaSubmitDeadline: MayaSubmitDeadlineModel = SettingsField(
         default_factory=MayaSubmitDeadlineModel,
         title="Maya")
-    MaxSubmitDeadline: MaxSubmitDeadlineModel = SettingsField(
-        default_factory=MaxSubmitDeadlineModel,
-        title="3ds Max")
     NukeSubmitDeadline: NukeSubmitDeadlineModel = SettingsField(
         default_factory=NukeSubmitDeadlineModel,
         title="Nuke")
@@ -538,9 +522,6 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
         "strict_error_checking": True,
         "tile_priority": 50,
         "scene_patches": []
-    },
-    "MaxSubmitDeadline": {
-        "use_local_temp": True
     },
     "NukeSubmitDeadline": {
         "use_gpu": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -234,6 +234,19 @@ class MayaSubmitDeadlineModel(BaseSettingsModel):
         return value
 
 
+class MaxSubmitDeadlineModel(BaseSettingsModel):
+    """3ds Max-specific settings"""
+    use_local_temp: bool = SettingsField(
+        True,
+        title="Use local temp directory",
+        description=(
+            "Use local temp directory on render node for storing temporary "
+            "files related to the submission. Temporary files are deleted "
+            "after the job is finished."
+        )
+    )
+
+
 def fusion_deadline_plugin_enum():
     """Return a list of value/label dicts for the enumerator.
 
@@ -397,6 +410,9 @@ class PublishPluginsModel(BaseSettingsModel):
     MayaSubmitDeadline: MayaSubmitDeadlineModel = SettingsField(
         default_factory=MayaSubmitDeadlineModel,
         title="Maya")
+    MaxSubmitDeadline: MaxSubmitDeadlineModel = SettingsField(
+        default_factory=MaxSubmitDeadlineModel,
+        title="3ds Max")
     NukeSubmitDeadline: NukeSubmitDeadlineModel = SettingsField(
         default_factory=NukeSubmitDeadlineModel,
         title="Nuke")
@@ -522,6 +538,9 @@ DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
         "strict_error_checking": True,
         "tile_priority": 50,
         "scene_patches": []
+    },
+    "MaxSubmitDeadline": {
+        "use_local_temp": True
     },
     "NukeSubmitDeadline": {
         "use_gpu": True,


### PR DESCRIPTION
## Changelog Description
This PR is to add options to let the user choose whether they want to use temporary directory for preload maxscript. If the options is disabled, the preload maxscript would store in `your project directory/{published_workfile}` instead of local temporary directory. This is to avoid the system finding a local user folder that does not exist.
Fixes: https://github.com/ynput/ayon-3dsmax/issues/111

## Additional review information
You need to build and install deadline addon with this branch

## Testing notes:
1. Add your preferred `AYON_TMPDIR` into `ayon+settings://applications/applications/adsk_3dsmax/environment`
<img width="1148" height="895" alt="image" src="https://github.com/user-attachments/assets/26f95dd4-a1ad-454a-a627-ff82e5a794fa" />

2. Create Render from Max
3. Publish
