### PR TITLE
Job Output Filenames: also detect sequences when using `_` separator before frame number

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -200,10 +200,12 @@ class AbstractSubmitDeadline(
             due to remapping workfile to published workfile.
         Used in JobOutput > Explore output
         """
+        # clique.PATTERNS["frames"] but also allow `_` before digits
+        pattern = r"(?P<index>(?P<padding>0*)\d+)\.\D+\d?$"
         collections, remainder = clique.assemble(
             iter_expected_files(instance.data["expectedFiles"]),
             assume_padded_when_ambiguous=True,
-            patterns=[clique.PATTERNS["frames"]])
+            patterns=[pattern])
         paths = []
         for collection in collections:
             padding = "#" * collection.padding


### PR DESCRIPTION
## Changelog Description

Also detect sequences with `_` separator, like `layer_1001.exr`

## Additional review information

Fix: https://github.com/ynput/ayon-cinema4d/issues/50

## Testing notes:
1. Renders with `_` separator before frame number should still have Job Output specified with `#` tokens.

<img width="702" height="91" alt="image" src="https://github.com/user-attachments/assets/9caa2bc6-ab53-4ff1-906e-569ef885d65b" />

Like this, but for `_`.
Note: This will only happen if the submission has more than one frame.