### PR TITLE
Fix/241 remove chunksize limit

### DIFF
--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -606,6 +606,10 @@ class DeadlineJobInfo:
             if not isinstance(value, DeadlineKeyValueVar):
                 setattr(self, attr_name, value)
 
+        # chunk size of 0 = "unlimited"
+        if self.ChunkSize <= 0:
+            self.ChunkSize = 2147483647
+
     def __setattr__(self, key, value):
         if value is None:
             super().__setattr__(key, value)

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -612,11 +612,11 @@ class DeadlineJobInfo:
             if not isinstance(value, DeadlineKeyValueVar):
                 setattr(self, attr_name, value)
 
-        # chunk size of 0 = "unlimited"
-        if self.ChunkSize == 0:
-            self.ChunkSize = MAX_CHUNK_SIZE
-
     def __setattr__(self, key, value):
+        # ChunkSize=0 means "unlimited" - convert to max chunk size
+        if key == "ChunkSize" and value == 0:
+            value = MAX_CHUNK_SIZE
+
         if value is None:
             super().__setattr__(key, value)
             return

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field, fields
 from functools import partial
 import typing
@@ -30,6 +32,10 @@ FARM_FAMILIES = [
 # DEPRECATED: Use `FARM_JOB_ENV_DATA_KEY` from `ayon_core.pipeline.publish`
 #     This variable is NOT USED anywhere in deadline addon.
 JOB_ENV_DATA_KEY: str = "farmJobEnv"
+
+
+MAX_CHUNK_SIZE = 2147483647
+"""Maximum chunk size for Deadline."""
 
 
 @dataclass
@@ -373,12 +379,12 @@ class DeadlineJobInfo:
     SecondaryPool: Optional[str] = field(default=None)
     # Default: "none"
     Group: Optional[str] = field(default=None)
-    Priority: int = field(default=None)
-    ChunkSize: int = field(default=0)
-    ConcurrentTasks: int = field(default=None)
+    Priority: int | None = field(default=None)
+    ChunkSize: int | None = field(default=None)
+    ConcurrentTasks: int | None = field(default=None)
     # Default: "true"
     LimitConcurrentTasksToNumberOfCpus: Optional[bool] = field(default=None)
-    OnJobComplete: str = field(default=None)
+    OnJobComplete: str | None = field(default=None)
     # Default: false
     SynchronizeAllAuxiliaryFiles: Optional[bool] = field(default=None)
     # Default: false
@@ -607,8 +613,8 @@ class DeadlineJobInfo:
                 setattr(self, attr_name, value)
 
         # chunk size of 0 = "unlimited"
-        if self.ChunkSize <= 0:
-            self.ChunkSize = 2147483647
+        if self.ChunkSize == 0:
+            self.ChunkSize = MAX_CHUNK_SIZE
 
     def __setattr__(self, key, value):
         if value is None:

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -374,7 +374,7 @@ class DeadlineJobInfo:
     # Default: "none"
     Group: Optional[str] = field(default=None)
     Priority: int = field(default=None)
-    ChunkSize: int = field(default=None)
+    ChunkSize: int = field(default=0)
     ConcurrentTasks: int = field(default=None)
     # Default: "true"
     LimitConcurrentTasksToNumberOfCpus: Optional[bool] = field(default=None)

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -21,6 +21,7 @@ from ayon_core.addon import AddonsManager
 
 from ayon_deadline.lib import (
     FARM_FAMILIES,
+    MAX_CHUNK_SIZE,
     PublishDeadlineJobInfo,
     DeadlineWebserviceError,
 )
@@ -344,7 +345,7 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 default=default_values.get("chunk_size"),
                 decimals=0,
                 minimum=0,
-                maximum=2147483647,   # default maximum for Deadline
+                maximum=MAX_CHUNK_SIZE,
             ),
             NumberDef(
                 "concurrent_tasks",

--- a/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
+++ b/client/ayon_deadline/plugins/publish/global/collect_jobinfo.py
@@ -343,8 +343,8 @@ class CollectJobInfo(pyblish.api.InstancePlugin, AYONPyblishPluginMixin):
                 label="Frames Per Task",
                 default=default_values.get("chunk_size"),
                 decimals=0,
-                minimum=1,
-                maximum=1000
+                minimum=0,
+                maximum=2147483647,   # default maximum for Deadline
             ),
             NumberDef(
                 "concurrent_tasks",

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_cache_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_cache_deadline.py
@@ -10,6 +10,7 @@ from ayon_core.pipeline import (
     AYONPyblishPluginMixin
 )
 from ayon_deadline import abstract_submit_deadline
+from ayon_deadline.lib import MAX_CHUNK_SIZE
 
 
 @dataclass
@@ -76,7 +77,7 @@ class HoudiniCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
         # Set the chunk size to a large number because multiple
         #  machines cannot render to the same file.
         if isinstance(instance.data.get("frames"), str):
-            job_info.ChunkSize = 99999999
+            job_info.ChunkSize = MAX_CHUNK_SIZE
 
         return job_info
 

--- a/client/ayon_deadline/plugins/publish/maya/submit_maya_cache_deadline.py
+++ b/client/ayon_deadline/plugins/publish/maya/submit_maya_cache_deadline.py
@@ -14,6 +14,7 @@ from ayon_core.pipeline import (
 from ayon_deadline import abstract_submit_deadline
 
 from ayon_deadline.scripts import remote_publish
+from ayon_deadline.lib import MAX_CHUNK_SIZE
 
 
 @dataclass
@@ -57,7 +58,7 @@ class MayaCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,  
         job_info.Name = job_name
         job_info.BatchName = batch_name
         job_info.Plugin = "MayaBatch"
-        job_info.ChunkSize = 99999999
+        job_info.ChunkSize = MAX_CHUNK_SIZE
 
         job_info.EnvironmentKeyValue["INSTANCE_IDS"] = instance.name
         job_info.EnvironmentKeyValue["AYON_REMOTE_PUBLISH"] = "1"

--- a/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
+++ b/client/ayon_deadline/plugins/publish/nuke/submit_nuke_deadline.py
@@ -10,6 +10,7 @@ from ayon_core.pipeline.publish import (
     AYONPyblishPluginMixin
 )
 from ayon_deadline import abstract_submit_deadline
+from ayon_deadline.lib import MAX_CHUNK_SIZE
 
 
 @dataclass
@@ -124,7 +125,7 @@ class NukeSubmitDeadline(
                 self.job_info.Name = os.path.basename(render_path)
 
                 # baking job shouldn't be split
-                self.job_info.ChunkSize = 999999
+                self.job_info.ChunkSize = MAX_CHUNK_SIZE
 
                 self.job_info.Frames = f"{start_frame}-{end_frame}"
 


### PR DESCRIPTION
## Changelog Description
allow users to use chunksizes beyond 999 and allows to use "0" as an maximum chunksize

## Additional review information
Detailed information of the changes made to the product or service, providing an in-depth description of the updates and enhancements. This can include technical information, code examples and anything else needed for the review of the PR.

## Testing notes:

ideally use a frame range larger than 999 frames. I'm using 4000 frames in my test

Test 1
1. increase chunksize to any value >999
2. submit a test job
3. confirm chunks are grouped using that value
<img width="1725" height="861" alt="image" src="https://github.com/user-attachments/assets/4218348f-09fc-4769-a73d-98da79e21060" />


Test 2
1. set chunksize to 0
2. submit a test job
3. confirm a single chunk is submitted
<img width="1725" height="861" alt="image" src="https://github.com/user-attachments/assets/d7b9ce01-2ab2-42e1-a619-51dda00f3c02" />

Test 3:
1. set chunksize to a normal value (eg.: 10 or 20)
2. submit a test job
3. confirm chunks of 10 are submitted
<img width="1653" height="897" alt="image" src="https://github.com/user-attachments/assets/44d08b7c-484b-4aa3-ba1f-24ef3f0e6457" />


solves: https://github.com/ynput/ayon-deadline/issues/241
