### PR TITLE
Custom frame range implementation in 3dsmax farm submission

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -43,7 +43,14 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             start=int(instance.data["frameStart"]),
             end=int(instance.data["frameEnd"])
         )
-        job_info.Frames = frames
+        # already collected explicit values for rendered Frames
+        if not job_info.Frames:
+            # Deadline requires integers in frame range
+            frames = "{start}-{end}".format(
+                start=int(instance.data["frameStart"]),
+                end=int(instance.data["frameEnd"])
+            )
+            job_info.Frames = frames
 
         # do not add expected files for multiCamera
         if instance.data.get("multiCamera"):

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -38,11 +38,6 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         job_info.Plugin = instance.data.get("plugin") or "3dsmax"
 
         job_info.EnableAutoTimeout = True
-        # Deadline requires integers in frame range
-        frames = "{start}-{end}".format(
-            start=int(instance.data["frameStart"]),
-            end=int(instance.data["frameEnd"])
-        )
         # already collected explicit values for rendered Frames
         if not job_info.Frames:
             # Deadline requires integers in frame range


### PR DESCRIPTION
## Changelog Description
This PR is to add support for custom frame range in farm submission for 3dsmax.
Resolve: https://github.com/ynput/ayon-deadline/issues/244
## Additional review information
n/a

## Testing notes:
1. Create Render
2. Publish with/without custom frame range
3. Should be working
