### PR TITLE
Max: Store Preload Script with normalized path in render directory

### DIFF
--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -309,10 +309,20 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             for file in exp:
                 yield file
 
-    def tmp_pre_load_max_script(self, expected_files, original_workfile, publish_workfile):
+    def tmp_pre_load_max_script(
+            self,
+            expected_files: dict,
+            original_workfile: str,
+            publish_workfile: str
+        ) -> str:
         """Temporary function to provide pre-load maxscript for deadline
         submission. This is a workaround for Deadline issue where it
         doesn't load the scene properly before rendering.
+
+        Args:
+            expected_files (dict): A dictionary of expected rendered files.
+            original_workfile (str): The original workfile name pattern.
+            publish_workfile (str): The published workfile name pattern.
 
         Returns:
             str: Maxscript code as a string.

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -170,8 +170,8 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             "resolutionHeight", rt.renderHeight)
 
         published_workfile = os.path.basename(plugin_info["SceneFile"])
-        plugin_info["PostLoadScript"] = tmp_pre_load_max_script(
-            instance,
+        plugin_info["PostLoadScript"] = self.tmp_pre_load_max_script(
+            instance.data["expectedFiles"],
             instance.data["original_workfile_pattern"],
             os.path.splitext(published_workfile)[0],
         )
@@ -309,103 +309,102 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             for file in exp:
                 yield file
 
+    def tmp_pre_load_max_script(self, expected_files, original_workfile, publish_workfile):
+        """Temporary function to provide pre-load maxscript for deadline
+        submission. This is a workaround for Deadline issue where it
+        doesn't load the scene properly before rendering.
 
-def tmp_pre_load_max_script(instance, original_workfile, publish_workfile):
-    """Temporary function to provide pre-load maxscript for deadline
-    submission. This is a workaround for Deadline issue where it
-    doesn't load the scene properly before rendering.
+        Returns:
+            str: Maxscript code as a string.
+        """
 
-    Returns:
-        str: Maxscript code as a string.
-    """
-
-    max_script = f"""
-fn PublishWorkfileRenderOutput =
-(
-    rendererName = renderers.production as string
-    original_workfile = "{original_workfile}"
-    publish_workfile = "{publish_workfile}"
-
-    if matchPattern rendererName pattern:"V_Ray*" then
+        max_script = f"""
+    fn PublishWorkfileRenderOutput =
     (
-        if matchPattern rendererName pattern:"*GPU*" then
-        (
-            original_filename = renderers.production.V_Ray_settings.output_rawfilename
-            new_filename = substituteString original_filename original_workfile publish_workfile
-            renderers.production.V_Ray_settings.output_rawfilename = new_filename
+        rendererName = renderers.production as string
+        original_workfile = "{original_workfile}"
+        publish_workfile = "{publish_workfile}"
 
-            if renderers.production.V_Ray_settings.output_splitgbuffer do
+        if matchPattern rendererName pattern:"V_Ray*" then
+        (
+            if matchPattern rendererName pattern:"*GPU*" then
             (
-                original_Aovfilename = renderers.production.V_Ray_settings.output_splitfilename
-                new_aovfilename = substituteString original_Aovfilename original_workfile publish_workfile
-                renderers.production.V_Ray_settings.output_splitfilename = new_aovfilename
+                original_filename = renderers.production.V_Ray_settings.output_rawfilename
+                new_filename = substituteString original_filename original_workfile publish_workfile
+                renderers.production.V_Ray_settings.output_rawfilename = new_filename
+
+                if renderers.production.V_Ray_settings.output_splitgbuffer do
+                (
+                    original_Aovfilename = renderers.production.V_Ray_settings.output_splitfilename
+                    new_aovfilename = substituteString original_Aovfilename original_workfile publish_workfile
+                    renderers.production.V_Ray_settings.output_splitfilename = new_aovfilename
+                )
             )
+            else
+            (
+                original_filename = renderers.production.output_rawfilename
+                new_filename = substituteString original_filename original_workfile publish_workfile
+                renderers.production.output_rawfilename = new_filename
+
+                if renderers.production.output_splitgbuffer do
+                (
+                    original_Aovfilename = renderers.production.output_splitfilename
+                    new_aovfilename = substituteString original_Aovfilename original_workfile publish_workfile
+                    renderers.production.output_splitfilename = new_aovfilename
+                )
+            )
+        )
+        else if matchPattern rendererName pattern:"Arnold*" then (
+            original_filename = rendOutputFilename
+            new_filename = substituteString original_filename original_workfile publish_workfile
+            rendOutputFilename = new_filename
+            aovmgr = renderers.production.AOVManager
+            original_arnold_filename = aovmgr.outputPath
+            new_arnold_filename = substituteString original_arnold_filename original_workfile publish_workfile
+            aovmgr.outputPath = new_arnold_filename
+
         )
         else
         (
-            original_filename = renderers.production.output_rawfilename
+            original_filename = rendOutputFilename
             new_filename = substituteString original_filename original_workfile publish_workfile
-            renderers.production.output_rawfilename = new_filename
+            rendOutputFilename = new_filename
 
-            if renderers.production.output_splitgbuffer do
+            rnMgr = maxOps.GetCurRenderElementMgr()
+            if rnMgr != undefined do
             (
-                original_Aovfilename = renderers.production.output_splitfilename
-                new_aovfilename = substituteString original_Aovfilename original_workfile publish_workfile
-                renderers.production.output_splitfilename = new_aovfilename
-            )
-        )
-    )
-    else if matchPattern rendererName pattern:"Arnold*" then (
-        original_filename = rendOutputFilename
-        new_filename = substituteString original_filename original_workfile publish_workfile
-        rendOutputFilename = new_filename
-        aovmgr = renderers.production.AOVManager
-        original_arnold_filename = aovmgr.outputPath
-        new_arnold_filename = substituteString original_arnold_filename original_workfile publish_workfile
-        aovmgr.outputPath = new_arnold_filename
-
-    )
-    else
-    (
-        original_filename = rendOutputFilename
-        new_filename = substituteString original_filename original_workfile publish_workfile
-        rendOutputFilename = new_filename
-
-        rnMgr = maxOps.GetCurRenderElementMgr()
-        if rnMgr != undefined do
-        (
-            for i = 0 to rnMgr.numrenderelements()-1 do
-            (
-                re = rnMgr.getrenderelement i
-                if re.enabled do
+                for i = 0 to rnMgr.numrenderelements()-1 do
                 (
-                    originAovfilename = rnMgr.GetRenderElementFileName i
-                    if originAovfilename != undefined and originAovfilename != "" do
+                    re = rnMgr.getrenderelement i
+                    if re.enabled do
                     (
-                        newAovfilename = substituteString originAovfilename original_workfile publish_workfile
-                        rnMgr.SetRenderElementFileName i newAovfilename
+                        originAovfilename = rnMgr.GetRenderElementFileName i
+                        if originAovfilename != undefined and originAovfilename != "" do
+                        (
+                            newAovfilename = substituteString originAovfilename original_workfile publish_workfile
+                            rnMgr.SetRenderElementFileName i newAovfilename
+                        )
                     )
                 )
             )
         )
+
+        return true
     )
 
-    return true
-)
+    -- Execute the function
+    renderOutputPublish = PublishWorkfileRenderOutput()
 
--- Execute the function
-renderOutputPublish = PublishWorkfileRenderOutput()
+    """  # noqa: E501
+        first_file = next(self._iter_expected_files(expected_files))
+        render_dir = Path(os.path.dirname(first_file))
+        render_dir.mkdir(parents=True, exist_ok=True)
+        script_path = render_dir / "pre_load_max_script.ms"
 
-"""  # noqa: E501
-    exp = instance.data["expectedFiles"][0]
-    render_dir = Path(os.path.dirname(exp))
-    render_dir.mkdir(parents=True, exist_ok=True)
-    script_path = render_dir / "pre_load_max_script.ms"
-
-    try:
-        with open(script_path, "w") as script_file:
-            script_file.write(max_script)
-        print(f"Temporary pre-load maxscript created at: {script_path}")
-        return script_path
-    except Exception as e:
-        raise RuntimeError(f"Error creating maxscript file: {str(e)}")
+        try:
+            with open(script_path, "w") as script_file:
+                script_file.write(max_script)
+            print(f"Temporary pre-load maxscript created at: {script_path}")
+            return script_path
+        except Exception as e:
+            raise RuntimeError(f"Error creating maxscript file: {str(e)}")

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -415,6 +415,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
             with open(script_path, "w") as script_file:
                 script_file.write(max_script)
             print(f"Temporary pre-load maxscript created at: {script_path}")
-            return script_path
+            return str(script_path)
+
         except Exception as e:
             raise RuntimeError(f"Error creating maxscript file: {str(e)}")

--- a/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
+++ b/client/ayon_deadline/plugins/publish/max/submit_max_deadline.py
@@ -1,11 +1,10 @@
 import os
 import copy
+from pathlib import Path
 from dataclasses import dataclass, field, asdict
 
-from ayon_core.pipeline import (
-    AYONPyblishPluginMixin,
-    tempdir
-)
+from ayon_core.pipeline import AYONPyblishPluginMixin
+
 from ayon_core.pipeline.publish import KnownPublishError
 from ayon_max.api.lib import (
     get_current_renderer,
@@ -319,7 +318,6 @@ def tmp_pre_load_max_script(instance, original_workfile, publish_workfile):
     Returns:
         str: Maxscript code as a string.
     """
-    temp_dir = tempdir.get_temp_dir(instance.context.data["projectName"])
 
     max_script = f"""
 fn PublishWorkfileRenderOutput =
@@ -399,8 +397,10 @@ fn PublishWorkfileRenderOutput =
 renderOutputPublish = PublishWorkfileRenderOutput()
 
 """  # noqa: E501
-
-    script_path = os.path.join(temp_dir, "pre_load_max_script.ms")
+    exp = instance.data["expectedFiles"][0]
+    render_dir = Path(os.path.dirname(exp))
+    render_dir.mkdir(parents=True, exist_ok=True)
+    script_path = render_dir / "pre_load_max_script.ms"
 
     try:
         with open(script_path, "w") as script_file:


### PR DESCRIPTION
## Changelog Description
This PR is to make sure Preload Script is with normalized path which supports for cross-platform and network/unc path.
The script would be also stored in the render output directory so that it's easier for users to access and debug the max script for rendering.
Resolve https://github.com/ynput/ayon-3dsmax/issues/127

## Additional review information
Tested with network path

## Testing notes:
1. Create Render with farm rendering option in 3dsmax
2. Publish
3. Render should be successfully published without any permission error, 
