### PR TITLE
feat: Add tile rendering support for USD render on Deadline

### DIFF
--- a/client/ayon_deadline/abstract_submit_deadline.py
+++ b/client/ayon_deadline/abstract_submit_deadline.py
@@ -141,33 +141,45 @@ class AbstractSubmitDeadline(
         # TODO: Find a way that's more generic and not render type specific
         #  This is currently only HoudiniSubmitDeadline-specific
         if instance.data.get("splitRender"):
-            dependency_job_ids = []
-            if job_id:
-                self.log.info("Splitting export and render in two jobs")
-                self.log.info("Export job id: %s", job_id)
-                dependency_job_ids = [job_id]
-            # When submitting a render job separate from the export job,
-            # we do not want to use the DCC's DL plugin. Instead, we
-            # want to use the renderer's dedicated DL plugin.
-            # The `get_job_info` method should be responsible for setting
-            # the correct DL plugin for the render job. For implementation
-            # examples, check `HoudiniSubmitDeadline.get_job_info`.
-            render_job_info = self.get_job_info(
-                job_info=job_info,
-                dependency_job_ids=dependency_job_ids,
-                use_dcc_plugin=False
-            )
-            render_plugin_info = self.get_plugin_info(job_type="render")
-            payload = self.assemble_payload(
-                job_info=render_job_info,
-                plugin_info=render_plugin_info
-            )
-            auth = instance.data["deadline"]["auth"]
-            verify = instance.data["deadline"]["verify"]
-            render_job_id = self.submit(payload, auth, verify)
+            self._submit_split_render_jobs(instance, job_id, job_info)
 
-            instance.data["deadline"]["job_info"] = deepcopy(render_job_info)
-            self.log.info("Render job id: %s", render_job_id)
+    def _submit_split_render_jobs(
+        self, instance, job_id, job_info
+    ):
+        """Submit render job(s) depending on the export job.
+
+        Default submits one render job using the renderer's dedicated DL
+        plugin (see `HoudiniSubmitDeadline.get_job_info` for how the
+        plugin swap is wired via `use_dcc_plugin=False`). Override to
+        submit multiple — e.g. tile rendering fans out N jobs.
+        """
+        dependency_job_ids = []
+        if job_id:
+            self.log.info("Splitting export and render in two jobs")
+            self.log.info("Export job id: %s", job_id)
+            dependency_job_ids = [job_id]
+        # When submitting a render job separate from the export job,
+        # we do not want to use the DCC's DL plugin. Instead, we
+        # want to use the renderer's dedicated DL plugin.
+        # The `get_job_info` method should be responsible for setting
+        # the correct DL plugin for the render job. For implementation
+        # examples, check `HoudiniSubmitDeadline.get_job_info`.
+        render_job_info = self.get_job_info(
+            job_info=job_info,
+            dependency_job_ids=dependency_job_ids,
+            use_dcc_plugin=False
+        )
+        render_plugin_info = self.get_plugin_info(job_type="render")
+        payload = self.assemble_payload(
+            job_info=render_job_info,
+            plugin_info=render_plugin_info
+        )
+        auth = instance.data["deadline"]["auth"]
+        verify = instance.data["deadline"]["verify"]
+        render_job_id = self.submit(payload, auth, verify)
+
+        instance.data["deadline"]["job_info"] = deepcopy(render_job_info)
+        self.log.info("Render job id: %s", render_job_id)
 
     def _set_scene_path(
         self,

--- a/client/ayon_deadline/plugins/publish/global/assemble_render_tiles.py
+++ b/client/ayon_deadline/plugins/publish/global/assemble_render_tiles.py
@@ -1,0 +1,165 @@
+import os
+import subprocess
+
+import pyblish.api
+
+from ayon_core.lib import get_oiio_tool_args
+
+
+class AssembleRenderTiles(pyblish.api.InstancePlugin):
+    """Assemble per-tile EXRs into the canonical render-product files.
+
+    Runs on the worker, inside the AYON publish job that Deadline launches
+    after all tile render jobs are done. Resolves oiiotool against the
+    worker's local AYON installation (so home-dir / addon-version drift
+    between submitter and worker doesn't matter).
+
+    Tile config travels in 'instance.data["publishJobMetadata"]
+    ["tile_assembly"]', stashed there by 'submit_publish_job.py' on the
+    submitter. Tile EXRs live alongside the canonical file with a
+    'TileSuffixPattern % index' suffix inserted before the extension
+    (Husk's '--tile-suffix' behaviour).
+
+    Two merge strategies are used depending on the EXR contents:
+      - Non-deep tiles use '--add:allsubimages=1'. Husk writes each tile
+        with full display window but data window only over the tile rect,
+        and pixel data only inside that rect — so summing the four tiles
+        is equivalent to compositing, and ':allsubimages=1' keeps every
+        AOV subimage (which lack alpha and can't use '--over').
+      - Deep tiles use '--deepmerge'. oiiotool's pixel-add ops reject
+        deep images outright; '--deepmerge' takes the union of samples
+        across the inputs, which is exactly what tiled deep renders need
+        (each tile contributes samples only inside its rect).
+    """
+
+    label = "Assemble Render Tiles"
+    # End of collection: after CollectRenderedFiles (-0.2) populates
+    # 'representations', before ValidateExpectedFiles (order 1) checks
+    # the canonical files exist on disk.
+    order = pyblish.api.CollectorOrder + 0.499
+    targets = ["deadline", "farm"]
+    families = ["render", "prerender", "renderlayer", "usdrender"]
+
+    def process(self, instance):
+        publish_metadata = instance.data.get("publishJobMetadata") or {}
+        tile_cfg = publish_metadata.get("tile_assembly")
+        if not tile_cfg:
+            return
+
+        tiles_x = int(tile_cfg["tilesX"])
+        tiles_y = int(tile_cfg["tilesY"])
+        suffix_pattern = tile_cfg.get("tileSuffixPattern", "_tile%02d")
+        tile_count = tiles_x * tiles_y
+        if tile_count < 2:
+            return
+
+        oiio_args = get_oiio_tool_args("oiiotool")
+
+        for repre in instance.data.get("representations") or []:
+            staging_dir = repre.get("stagingDir")
+            if not staging_dir:
+                continue
+            files = repre.get("files")
+            if not files:
+                continue
+            # 'files' is either a list of basenames (sequences) or a
+            # single basename (single-file remainders).
+            if isinstance(files, str):
+                files = [files]
+
+            # Deep-ness is uniform across all frames of one render
+            # product, so probe once per representation off the first
+            # frame's first tile.
+            first_tile = self._tile_path_for(
+                staging_dir, files[0], 0, suffix_pattern
+            )
+            if not os.path.exists(first_tile):
+                raise RuntimeError(
+                    "Tile EXR missing for assembly: {}".format(first_tile)
+                )
+            merge_op = self._choose_merge_op(oiio_args, first_tile)
+            self.log.debug(
+                "Representation '%s' (%s frames): using %s",
+                repre.get("name"), len(files), merge_op,
+            )
+
+            for filename in files:
+                self._assemble_one(
+                    oiio_args,
+                    staging_dir,
+                    filename,
+                    tile_count,
+                    suffix_pattern,
+                    merge_op,
+                )
+
+    def _tile_path_for(self, staging_dir, filename, tile_index, suffix_pattern):
+        canonical = os.path.join(staging_dir, filename)
+        base, ext = os.path.splitext(canonical)
+        return "{}{}{}".format(base, suffix_pattern % tile_index, ext)
+
+    def _choose_merge_op(self, oiio_args, sample_path):
+        """Return the oiiotool op string used to combine consecutive tiles.
+
+        Detects deep vs. non-deep via 'oiiotool --info -i:infoformat=xml':
+        oiio emits '<deep>1</deep>' in the per-image XML for deep EXRs.
+        Plain-text '--info' output doesn't reliably mark deep across
+        oiio versions, so we use the XML form (same one AYON's
+        'transcoding.py' uses).
+        """
+        try:
+            result = subprocess.run(
+                list(oiio_args) + [
+                    "--info", "-i:infoformat=xml", sample_path
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                "oiiotool --info failed for '{}': {}".format(
+                    sample_path, (exc.stderr or "").strip()
+                )
+            )
+        xml_blob = (result.stdout or "") + (result.stderr or "")
+        is_deep = "<deep>1</deep>" in xml_blob
+        return "--deepmerge" if is_deep else "--add:allsubimages=1"
+
+    def _assemble_one(
+        self,
+        oiio_args,
+        staging_dir,
+        filename,
+        tile_count,
+        suffix_pattern,
+        merge_op,
+    ):
+        canonical_path = os.path.join(staging_dir, filename)
+
+        cmd = list(oiio_args)
+        for i in range(tile_count):
+            tile_path = self._tile_path_for(
+                staging_dir, filename, i, suffix_pattern
+            )
+            if not os.path.exists(tile_path):
+                raise RuntimeError(
+                    "Tile EXR missing for assembly: {}".format(tile_path)
+                )
+            cmd.append(tile_path)
+            if i > 0:
+                cmd.append(merge_op)
+        cmd.extend(["-o", canonical_path])
+
+        self.log.info(
+            "Assembling %s tiles (%s) -> %s",
+            tile_count, merge_op, canonical_path,
+        )
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                "oiiotool tile assembly failed for '{}': exit {}".format(
+                    canonical_path, exc.returncode
+                )
+            )

--- a/client/ayon_deadline/plugins/publish/global/assemble_render_tiles.py
+++ b/client/ayon_deadline/plugins/publish/global/assemble_render_tiles.py
@@ -38,7 +38,7 @@ class AssembleRenderTiles(pyblish.api.InstancePlugin):
     # the canonical files exist on disk.
     order = pyblish.api.CollectorOrder + 0.499
     targets = ["deadline", "farm"]
-    families = ["render", "prerender", "renderlayer", "usdrender"]
+    families = ["usdrender"]
 
     def process(self, instance):
         publish_metadata = instance.data.get("publishJobMetadata") or {}

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -442,6 +442,20 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         if deadline_publish_job_id:
             publish_job["deadline_publish_job_id"] = deadline_publish_job_id
 
+        # Tile rendering: surface the assembly config to the worker. The
+        # AssembleRenderTiles plugin reads this from
+        # instance.data["publishJobMetadata"]["tile_assembly"] (which
+        # CollectRenderedFiles populates from this dict) and runs oiiotool
+        # on the worker before validation/integration.
+        if instance.data.get("tileRendering"):
+            publish_job["tile_assembly"] = {
+                "tilesX": instance.data["tilesX"],
+                "tilesY": instance.data["tilesY"],
+                "tileSuffixPattern": instance.data.get(
+                    "tileSuffixPattern", "_tile%02d"
+                ),
+            }
+
         # add audio to metadata file if available
         audio_file = instance.context.data.get("audioFile")
         if audio_file and os.path.isfile(audio_file):

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -1,22 +1,15 @@
 import os
-import re
 from copy import deepcopy
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 
 import pyblish.api
 
-# Frame-token placeholders Houdini uses in render-product paths
-# (e.g. "....1###.exr" or "....$F4.exr"). Replaced with Deadline's
-# <STARTFRAME> token for per-task substitution at render time.
-_FRAME_TOKEN_RE = re.compile(r"#+|\$F\d*")
-
 from ayon_core.pipeline import AYONPyblishPluginMixin
 from ayon_core.lib import (
     is_in_tests,
     TextDef,
     NumberDef,
-    get_oiio_tool_args,
 )
 from ayon_deadline import abstract_submit_deadline
 
@@ -402,141 +395,6 @@ class HoudiniSubmitDeadline(
             TileSuffix=tile_suffix,
         )
 
-    def _build_tile_assembly_args(
-        self, file_patterns, tile_count, tile_suffix_pattern
-    ):
-        """Build the oiiotool argument string that merges N tile EXRs into
-        the original render-product path, for each render product.
-
-        Husk wrote each tile as a cropped multipart OpenEXR — display
-        window is the full image, data window is the tile's rectangle,
-        pixel data only in that rectangle. The file typically has
-        multiple subimages: subimage 0 is RGBA beauty, additional
-        subimages are 3-channel AOVs (normals, position, cryptomatte,
-        etc.) without alpha.
-
-        We can't use `--over` because the AOV subimages have no alpha
-        channel. Instead we use `--add:allsubimages=1`: since the four
-        tiles' data windows don't overlap, summing them produces the
-        same result as compositing, and `:allsubimages=1` applies the
-        op to every subimage in parallel so all AOVs survive.
-
-        Frame placeholder tokens ('####', '$F4', etc.) in the input
-        patterns are replaced with Deadline's <STARTFRAME> token so each
-        per-task command resolves to a concrete frame number at run time.
-        """
-        args = []
-        for pattern in file_patterns:
-            canonical = _FRAME_TOKEN_RE.sub("<STARTFRAME>", pattern)
-            base, ext = os.path.splitext(canonical)
-            for i in range(tile_count):
-                # tile_suffix_pattern is a printf string like "_tile%02d"
-                # that husk substitutes with the tile index.
-                tile_suffix = tile_suffix_pattern % i
-                tile_path = "{}{}{}".format(base, tile_suffix, ext)
-                args.append("<QUOTE>{}<QUOTE>".format(tile_path))
-                if i > 0:
-                    args.append("--add:allsubimages=1")
-            args.append("-o")
-            args.append("<QUOTE>{}<QUOTE>".format(canonical))
-        return " ".join(args)
-
-    def _submit_tile_assembly_job(
-        self,
-        instance,
-        tiles_x,
-        tiles_y,
-        tile_suffix_pattern,
-        depends_on,
-        generic_job_info,
-        auth,
-        verify,
-    ):
-        """Submit a Deadline CommandLine job that merges per-tile EXRs into
-        the final render-product path using oiiotool's --over chain.
-
-        One task per frame (ChunkSize=1, IsFrameDependent=True) so a frame
-        can assemble as soon as all its tile-job tasks for that frame are
-        done. The whole assembly job depends on every tile render job, so
-        nothing starts until the tile fan-out is at least partially through.
-        """
-        file_patterns = instance.data.get("files") or []
-        if not file_patterns:
-            self.log.warning(
-                "Tile assembly skipped: instance has no 'files' "
-                "(render product paths) to merge."
-            )
-            return None
-        if not depends_on:
-            self.log.warning(
-                "Tile assembly skipped: no tile job ids to depend on."
-            )
-            return None
-
-        tile_count = tiles_x * tiles_y
-        arguments = self._build_tile_assembly_args(
-            file_patterns, tile_count, tile_suffix_pattern
-        )
-
-        # Build JobInfo. We start from generic_job_info and override the
-        # Plugin to CommandLine; get_job_info() would otherwise set it to
-        # HuskStandalone for usdrender + use_dcc_plugin=False.
-        assembly_job_info = self.get_job_info(
-            job_info=deepcopy(generic_job_info),
-            dependency_job_ids=depends_on,
-            use_dcc_plugin=False,
-        )
-        assembly_job_info.Plugin = "CommandLine"
-        assembly_job_info.Name = "{} (assemble tiles)".format(
-            assembly_job_info.Name
-        )
-        assembly_job_info.IsFrameDependent = True
-        assembly_job_info.ChunkSize = 1
-        # Output paths for Deadline's "View Output" come from get_job_info()
-        # above, which walks instance.data["files"] and appends each path's
-        # dirname/basename via the +=-style container that
-        # PublishDeadlineJobInfo uses. The canonical render product paths
-        # are exactly what the assembled outputs land at, so we don't need
-        # to touch OutputDirectory / OutputFilename here.
-
-        # Resolve oiiotool via AYON's canonical helper. It asks the
-        # ayon_third_party addon for the bundled binary path first
-        # (which is what other AYON tooling uses), falling back to
-        # AYON_OIIO_PATHS / system PATH. Returns a list of args; for
-        # standard installs that's a single executable path. We send
-        # args[0] to Deadline as Executable and prepend any extra
-        # args[1:] to Arguments (rare — only if oiiotool is wrapped).
-        oiio_args = get_oiio_tool_args("oiiotool")
-        if not oiio_args:
-            self.log.error(
-                "Tile assembly skipped: AYON couldn't resolve an "
-                "oiiotool executable. Check that the ayon_third_party "
-                "addon is installed and has finished its first-run "
-                "binary download, or set AYON_OIIO_PATHS."
-            )
-            return None
-        oiiotool_executable = oiio_args[0]
-        if len(oiio_args) > 1:
-            arguments = " ".join(oiio_args[1:]) + " " + arguments
-        plugin_info = {
-            "Executable": oiiotool_executable,
-            "Arguments": arguments,
-            "Shell": "default",
-            "ShellExecute": False,
-        }
-
-        payload = self.assemble_payload(
-            job_info=assembly_job_info,
-            plugin_info=plugin_info,
-        )
-        assembly_job_id = self.submit(payload, auth, verify)
-        self.log.info(
-            "Submitted tile assembly job (oiiotool, %s tiles per frame, "
-            "%s product(s)) to Deadline: %s",
-            tile_count, len(file_patterns), assembly_job_id,
-        )
-        return assembly_job_id
-
     def _get_families(self, instance: pyblish.api.Instance) -> "set[str]":
         product_base_type = instance.data.get("productBaseType")
         if not product_base_type:
@@ -566,9 +424,12 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
             return super().process(instance)
 
         # Tile rendering path: submit the export job, then fan out N tile
-        # render jobs (each with --tile-index/--tile-count via Husk PluginInfo)
-        # depending on the export job. Assembly job is a follow-up — for now
-        # tile outputs are produced as separate files with --tile-suffix.
+        # render jobs (each with --tile-index/--tile-count via Husk
+        # PluginInfo) depending on the export job. Per-tile EXRs land on
+        # disk with a '_tile##' suffix; the cross-DCC publish job that
+        # ProcessSubmittedJobOnFarm submits depends on these tile jobs and
+        # the AssembleRenderTiles plugin runs oiiotool inside that publish
+        # job to merge the tiles into the canonical render-product paths.
         self._instance = instance
         context = instance.context
         self._deadline_url = instance.data["deadline"]["url"]
@@ -663,27 +524,17 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
             "Tile rendering submitted: %s tile jobs queued.", tile_count,
         )
 
-        # Tile assembly job. One CommandLine job (Plugin=CommandLine) running
-        # oiiotool's --over chain, one task per frame, depending on all tile
-        # render jobs (whole-job deps) with IsFrameDependent=True so each
-        # merged frame picks up as soon as that frame's tiles complete.
-        assembly_job_id = self._submit_tile_assembly_job(
-            instance,
-            tiles_x=tiles_x,
-            tiles_y=tiles_y,
-            tile_suffix_pattern=tile_suffix_pattern,
-            depends_on=tile_job_ids,
-            generic_job_info=generic_job_info,
-            auth=auth,
-            verify=verify,
-        )
-        if assembly_job_id:
-            instance.data["tileAssemblyJobId"] = assembly_job_id
-            # The cross-DCC publish job (ProcessSubmittedJobOnFarm in
-            # submit_publish_job.py) reads `assemblySubmissionJobs` when
-            # tileRendering=True. Without this, JobDependencies is None
-            # and the publish task fires before the renders finish.
-            instance.data["assemblySubmissionJobs"] = [assembly_job_id]
+        # Suffix pattern Husk used for the tile renders. Stashed for the
+        # publish job's AssembleRenderTiles plugin (worker-side) to know
+        # how to reconstruct tile filenames from the canonical names.
+        instance.data["tileSuffixPattern"] = tile_suffix_pattern
+
+        # The publish job depends on the tile renders directly. We reuse
+        # the existing 'assemblySubmissionJobs' key that
+        # ProcessSubmittedJobOnFarm._get_dependency_ids reads when
+        # tileRendering=True — same key, just pointed at the tile jobs
+        # since assembly now happens inside the publish job itself.
+        instance.data["assemblySubmissionJobs"] = list(tile_job_ids)
 
         # Maintain the parent's "Store output dir for unified publisher" side
         # effect (mirrors HoudiniSubmitDeadline.process).

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -414,80 +414,41 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
         # output paths then do not match the actual rendered paths
         return
 
-    def process(self, instance):
-        if not instance.data.get("farm"):
-            self.log.debug("Render on farm is disabled. "
-                           "Skipping deadline submission.")
-            return
-
+    def _submit_split_render_jobs(
+        self, instance, job_id, job_info
+    ):
         if not instance.data.get("tileRendering"):
-            return super().process(instance)
+            return super()._submit_split_render_jobs(
+                instance, job_id, job_info
+            )
 
-        # Tile rendering path: submit the export job, then fan out N tile
-        # render jobs (each with --tile-index/--tile-count via Husk
-        # PluginInfo) depending on the export job. Per-tile EXRs land on
-        # disk with a '_tile##' suffix; the cross-DCC publish job that
-        # ProcessSubmittedJobOnFarm submits depends on these tile jobs and
-        # the AssembleRenderTiles plugin runs oiiotool inside that publish
-        # job to merge the tiles into the canonical render-product paths.
-        self._instance = instance
-        context = instance.context
-        self._deadline_url = instance.data["deadline"]["url"]
-        assert self._deadline_url, "Requires Deadline Webservice URL"
+        # Tile rendering path: fan out N tile render jobs (each with
+        # --tile-index/--tile-count via Husk PluginInfo) depending on the
+        # export job. Per-tile EXRs land on disk with a '_tile##' suffix;
+        # the cross-DCC publish job that ProcessSubmittedJobOnFarm submits
+        # depends on these tile jobs and the AssembleRenderTiles plugin
+        # runs oiiotool inside that publish job to merge the tiles into
+        # the canonical render-product paths.
+        # Husk takes a 2D grid via `--tile-count X Y` and a printf-style
+        # `--tile-suffix` (it substitutes %d-style tokens with the index
+        # itself), so the suffix is the same for every tile job and only
+        # TileIndex changes.
+        import hou
 
-        creator_attr = instance.data.get("creator_attributes", {})
-        export_skipped = (
-            creator_attr.get("render_target") == "local_export_farm_render"
-        )
-
-        # Build & submit the export job (mirrors AbstractSubmitDeadline.process)
-        generic_job_info = self.get_generic_job_info(instance)
-        self.job_info = self.get_job_info(job_info=deepcopy(generic_job_info))
-
-        self._set_scene_path(
-            context.data["currentFile"],
-            generic_job_info.use_published,
-            instance.data.get("stagingDir_is_custom", False),
-        )
-        if instance.data.get("expectedFiles"):
-            self._append_job_output_paths(instance, self.job_info)
-
-        self.plugin_info = self.get_plugin_info()
-        self.aux_files = self.get_aux_files()
-
-        plugin_info_data = instance.data["deadline"]["plugin_info_data"]
-        if plugin_info_data:
-            self.apply_additional_plugin_info(plugin_info_data)
-
-        export_job_id = None
-        if not export_skipped:
-            export_job_id = self.process_submission()
-            self.log.info("Submitted export job to Deadline: %s.", export_job_id)
-
-        instance.data["deadline"]["job_info"] = deepcopy(self.job_info)
-
-        # Fan out tile render jobs. Husk takes a 2D grid via
-        # `--tile-count X Y` and a printf-style `--tile-suffix` (it
-        # substitutes %d-style tokens with the index itself), so the suffix
-        # is the same for every tile job and only TileIndex changes.
         tiles_x = int(instance.data["tilesX"])
         tiles_y = int(instance.data["tilesY"])
         tile_count = tiles_x * tiles_y
-        # Husk substitutes %d-style tokens in --tile-suffix with the tile
-        # index itself, so we send the same printf pattern to every tile job.
         tile_suffix_pattern = "_tile%02d"
-        dependency_job_ids = [export_job_id] if export_job_id else []
+        dependency_job_ids = [job_id] if job_id else []
         auth = instance.data["deadline"]["auth"]
         verify = instance.data["deadline"]["verify"]
 
-        # Common Houdini version for the husk plugin.
-        import hou
         hou_major_minor = hou.applicationVersionString().rsplit(".", 1)[0]
 
         tile_job_ids = []
         for tile_index in range(tile_count):
             tile_job_info = self.get_job_info(
-                job_info=deepcopy(generic_job_info),
+                job_info=deepcopy(job_info),
                 dependency_job_ids=dependency_job_ids,
                 use_dcc_plugin=False,
             )
@@ -535,10 +496,3 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
         # tileRendering=True — same key, just pointed at the tile jobs
         # since assembly now happens inside the publish job itself.
         instance.data["assemblySubmissionJobs"] = list(tile_job_ids)
-
-        # Maintain the parent's "Store output dir for unified publisher" side
-        # effect (mirrors HoudiniSubmitDeadline.process).
-        if instance.data.get("files"):
-            instance.data["outputDir"] = os.path.dirname(
-                instance.data["files"][0]
-            )

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -1,14 +1,22 @@
 import os
+import re
+from copy import deepcopy
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 
 import pyblish.api
 
+# Frame-token placeholders Houdini uses in render-product paths
+# (e.g. "....1###.exr" or "....$F4.exr"). Replaced with Deadline's
+# <STARTFRAME> token for per-task substitution at render time.
+_FRAME_TOKEN_RE = re.compile(r"#+|\$F\d*")
+
 from ayon_core.pipeline import AYONPyblishPluginMixin
 from ayon_core.lib import (
     is_in_tests,
     TextDef,
-    NumberDef
+    NumberDef,
+    get_oiio_tool_args,
 )
 from ayon_deadline import abstract_submit_deadline
 
@@ -71,6 +79,15 @@ class HuskStandalonePluginInfo:
     RestartDelegate: str = field(default="")
     Version: str = field(default="")
     SlapCompSources: str = field(default="")
+    # Tile rendering. Husk wants `--tile-count X Y` (two values) and a
+    # printf-style `--tile-suffix` (e.g. `_tile%02d`); husk substitutes the
+    # tile index itself, so the suffix is the same for every tile job and
+    # only TileIndex varies. TileIndex=-1 / TilesX=0 / TilesY=0 mean
+    # "not a tile job".
+    TileIndex: int = field(default=-1)
+    TilesX: int = field(default=0)
+    TilesY: int = field(default=0)
+    TileSuffix: str = field(default="")
 
 
 class HoudiniSubmitDeadline(
@@ -333,7 +350,15 @@ class HoudiniSubmitDeadline(
         output_dir = os.path.dirname(instance.data["files"][0])
         instance.data["outputDir"] = output_dir
 
-    def _get_husk_standalone_plugin_info(self, instance, hou_major_minor):
+    def _get_husk_standalone_plugin_info(
+        self,
+        instance,
+        hou_major_minor,
+        tile_index=-1,
+        tiles_x=0,
+        tiles_y=0,
+        tile_suffix="",
+    ):
         # Not all hosts can import this module.
         import hou
 
@@ -370,8 +395,147 @@ class HoudiniSubmitDeadline(
             PostRender=rop_node.evalParm("husk_postrender"),
             RestartDelegate=restart_delegate,
             Version=hou_major_minor,
-            SlapCompSources="\n".join(slapcomps)
+            SlapCompSources="\n".join(slapcomps),
+            TileIndex=tile_index,
+            TilesX=tiles_x,
+            TilesY=tiles_y,
+            TileSuffix=tile_suffix,
         )
+
+    def _build_tile_assembly_args(
+        self, file_patterns, tile_count, tile_suffix_pattern
+    ):
+        """Build the oiiotool argument string that merges N tile EXRs into
+        the original render-product path, for each render product.
+
+        Husk wrote each tile as a cropped multipart OpenEXR — display
+        window is the full image, data window is the tile's rectangle,
+        pixel data only in that rectangle. The file typically has
+        multiple subimages: subimage 0 is RGBA beauty, additional
+        subimages are 3-channel AOVs (normals, position, cryptomatte,
+        etc.) without alpha.
+
+        We can't use `--over` because the AOV subimages have no alpha
+        channel. Instead we use `--add:allsubimages=1`: since the four
+        tiles' data windows don't overlap, summing them produces the
+        same result as compositing, and `:allsubimages=1` applies the
+        op to every subimage in parallel so all AOVs survive.
+
+        Frame placeholder tokens ('####', '$F4', etc.) in the input
+        patterns are replaced with Deadline's <STARTFRAME> token so each
+        per-task command resolves to a concrete frame number at run time.
+        """
+        args = []
+        for pattern in file_patterns:
+            canonical = _FRAME_TOKEN_RE.sub("<STARTFRAME>", pattern)
+            base, ext = os.path.splitext(canonical)
+            for i in range(tile_count):
+                # tile_suffix_pattern is a printf string like "_tile%02d"
+                # that husk substitutes with the tile index.
+                tile_suffix = tile_suffix_pattern % i
+                tile_path = "{}{}{}".format(base, tile_suffix, ext)
+                args.append("<QUOTE>{}<QUOTE>".format(tile_path))
+                if i > 0:
+                    args.append("--add:allsubimages=1")
+            args.append("-o")
+            args.append("<QUOTE>{}<QUOTE>".format(canonical))
+        return " ".join(args)
+
+    def _submit_tile_assembly_job(
+        self,
+        instance,
+        tiles_x,
+        tiles_y,
+        tile_suffix_pattern,
+        depends_on,
+        generic_job_info,
+        auth,
+        verify,
+    ):
+        """Submit a Deadline CommandLine job that merges per-tile EXRs into
+        the final render-product path using oiiotool's --over chain.
+
+        One task per frame (ChunkSize=1, IsFrameDependent=True) so a frame
+        can assemble as soon as all its tile-job tasks for that frame are
+        done. The whole assembly job depends on every tile render job, so
+        nothing starts until the tile fan-out is at least partially through.
+        """
+        file_patterns = instance.data.get("files") or []
+        if not file_patterns:
+            self.log.warning(
+                "Tile assembly skipped: instance has no 'files' "
+                "(render product paths) to merge."
+            )
+            return None
+        if not depends_on:
+            self.log.warning(
+                "Tile assembly skipped: no tile job ids to depend on."
+            )
+            return None
+
+        tile_count = tiles_x * tiles_y
+        arguments = self._build_tile_assembly_args(
+            file_patterns, tile_count, tile_suffix_pattern
+        )
+
+        # Build JobInfo. We start from generic_job_info and override the
+        # Plugin to CommandLine; get_job_info() would otherwise set it to
+        # HuskStandalone for usdrender + use_dcc_plugin=False.
+        assembly_job_info = self.get_job_info(
+            job_info=deepcopy(generic_job_info),
+            dependency_job_ids=depends_on,
+            use_dcc_plugin=False,
+        )
+        assembly_job_info.Plugin = "CommandLine"
+        assembly_job_info.Name = "{} (assemble tiles)".format(
+            assembly_job_info.Name
+        )
+        assembly_job_info.IsFrameDependent = True
+        assembly_job_info.ChunkSize = 1
+        # Output paths for Deadline's "View Output" come from get_job_info()
+        # above, which walks instance.data["files"] and appends each path's
+        # dirname/basename via the +=-style container that
+        # PublishDeadlineJobInfo uses. The canonical render product paths
+        # are exactly what the assembled outputs land at, so we don't need
+        # to touch OutputDirectory / OutputFilename here.
+
+        # Resolve oiiotool via AYON's canonical helper. It asks the
+        # ayon_third_party addon for the bundled binary path first
+        # (which is what other AYON tooling uses), falling back to
+        # AYON_OIIO_PATHS / system PATH. Returns a list of args; for
+        # standard installs that's a single executable path. We send
+        # args[0] to Deadline as Executable and prepend any extra
+        # args[1:] to Arguments (rare — only if oiiotool is wrapped).
+        oiio_args = get_oiio_tool_args("oiiotool")
+        if not oiio_args:
+            self.log.error(
+                "Tile assembly skipped: AYON couldn't resolve an "
+                "oiiotool executable. Check that the ayon_third_party "
+                "addon is installed and has finished its first-run "
+                "binary download, or set AYON_OIIO_PATHS."
+            )
+            return None
+        oiiotool_executable = oiio_args[0]
+        if len(oiio_args) > 1:
+            arguments = " ".join(oiio_args[1:]) + " " + arguments
+        plugin_info = {
+            "Executable": oiiotool_executable,
+            "Arguments": arguments,
+            "Shell": "default",
+            "ShellExecute": False,
+        }
+
+        payload = self.assemble_payload(
+            job_info=assembly_job_info,
+            plugin_info=plugin_info,
+        )
+        assembly_job_id = self.submit(payload, auth, verify)
+        self.log.info(
+            "Submitted tile assembly job (oiiotool, %s tiles per frame, "
+            "%s product(s)) to Deadline: %s",
+            tile_count, len(file_patterns), assembly_job_id,
+        )
+        return assembly_job_id
 
     def _get_families(self, instance: pyblish.api.Instance) -> "set[str]":
         product_base_type = instance.data.get("productBaseType")
@@ -391,3 +555,139 @@ class HoudiniSubmitDeadlineUsdRender(HoudiniSubmitDeadline):
         # Export Job doesn't seem to occur using the published path either, so
         # output paths then do not match the actual rendered paths
         return
+
+    def process(self, instance):
+        if not instance.data.get("farm"):
+            self.log.debug("Render on farm is disabled. "
+                           "Skipping deadline submission.")
+            return
+
+        if not instance.data.get("tileRendering"):
+            return super().process(instance)
+
+        # Tile rendering path: submit the export job, then fan out N tile
+        # render jobs (each with --tile-index/--tile-count via Husk PluginInfo)
+        # depending on the export job. Assembly job is a follow-up — for now
+        # tile outputs are produced as separate files with --tile-suffix.
+        self._instance = instance
+        context = instance.context
+        self._deadline_url = instance.data["deadline"]["url"]
+        assert self._deadline_url, "Requires Deadline Webservice URL"
+
+        creator_attr = instance.data.get("creator_attributes", {})
+        export_skipped = (
+            creator_attr.get("render_target") == "local_export_farm_render"
+        )
+
+        # Build & submit the export job (mirrors AbstractSubmitDeadline.process)
+        generic_job_info = self.get_generic_job_info(instance)
+        self.job_info = self.get_job_info(job_info=deepcopy(generic_job_info))
+
+        self._set_scene_path(
+            context.data["currentFile"],
+            generic_job_info.use_published,
+            instance.data.get("stagingDir_is_custom", False),
+        )
+        if instance.data.get("expectedFiles"):
+            self._append_job_output_paths(instance, self.job_info)
+
+        self.plugin_info = self.get_plugin_info()
+        self.aux_files = self.get_aux_files()
+
+        plugin_info_data = instance.data["deadline"]["plugin_info_data"]
+        if plugin_info_data:
+            self.apply_additional_plugin_info(plugin_info_data)
+
+        export_job_id = None
+        if not export_skipped:
+            export_job_id = self.process_submission()
+            self.log.info("Submitted export job to Deadline: %s.", export_job_id)
+
+        instance.data["deadline"]["job_info"] = deepcopy(self.job_info)
+
+        # Fan out tile render jobs. Husk takes a 2D grid via
+        # `--tile-count X Y` and a printf-style `--tile-suffix` (it
+        # substitutes %d-style tokens with the index itself), so the suffix
+        # is the same for every tile job and only TileIndex changes.
+        tiles_x = int(instance.data["tilesX"])
+        tiles_y = int(instance.data["tilesY"])
+        tile_count = tiles_x * tiles_y
+        # Husk substitutes %d-style tokens in --tile-suffix with the tile
+        # index itself, so we send the same printf pattern to every tile job.
+        tile_suffix_pattern = "_tile%02d"
+        dependency_job_ids = [export_job_id] if export_job_id else []
+        auth = instance.data["deadline"]["auth"]
+        verify = instance.data["deadline"]["verify"]
+
+        # Common Houdini version for the husk plugin.
+        import hou
+        hou_major_minor = hou.applicationVersionString().rsplit(".", 1)[0]
+
+        tile_job_ids = []
+        for tile_index in range(tile_count):
+            tile_job_info = self.get_job_info(
+                job_info=deepcopy(generic_job_info),
+                dependency_job_ids=dependency_job_ids,
+                use_dcc_plugin=False,
+            )
+            tile_job_info.Name = "{} (tile {}/{})".format(
+                tile_job_info.Name, tile_index + 1, tile_count
+            )
+
+            tile_plugin_info = asdict(self._get_husk_standalone_plugin_info(
+                instance,
+                hou_major_minor,
+                tile_index=tile_index,
+                tiles_x=tiles_x,
+                tiles_y=tiles_y,
+                tile_suffix=tile_suffix_pattern,
+            ))
+
+            payload = self.assemble_payload(
+                job_info=tile_job_info,
+                plugin_info=tile_plugin_info,
+            )
+            tile_job_id = self.submit(payload, auth, verify)
+            self.log.info(
+                "Submitted tile %s/%s to Deadline: %s",
+                tile_index + 1, tile_count, tile_job_id,
+            )
+            tile_job_ids.append(tile_job_id)
+
+            # Mirror parent's side effect for the last tile job so downstream
+            # publish plugins that read this still find a sensible value.
+            instance.data["deadline"]["job_info"] = deepcopy(tile_job_info)
+
+        instance.data["tileRenderJobIds"] = tile_job_ids
+        self.log.info(
+            "Tile rendering submitted: %s tile jobs queued.", tile_count,
+        )
+
+        # Tile assembly job. One CommandLine job (Plugin=CommandLine) running
+        # oiiotool's --over chain, one task per frame, depending on all tile
+        # render jobs (whole-job deps) with IsFrameDependent=True so each
+        # merged frame picks up as soon as that frame's tiles complete.
+        assembly_job_id = self._submit_tile_assembly_job(
+            instance,
+            tiles_x=tiles_x,
+            tiles_y=tiles_y,
+            tile_suffix_pattern=tile_suffix_pattern,
+            depends_on=tile_job_ids,
+            generic_job_info=generic_job_info,
+            auth=auth,
+            verify=verify,
+        )
+        if assembly_job_id:
+            instance.data["tileAssemblyJobId"] = assembly_job_id
+            # The cross-DCC publish job (ProcessSubmittedJobOnFarm in
+            # submit_publish_job.py) reads `assemblySubmissionJobs` when
+            # tileRendering=True. Without this, JobDependencies is None
+            # and the publish task fires before the renders finish.
+            instance.data["assemblySubmissionJobs"] = [assembly_job_id]
+
+        # Maintain the parent's "Store output dir for unified publisher" side
+        # effect (mirrors HoudiniSubmitDeadline.process).
+        if instance.data.get("files"):
+            instance.data["outputDir"] = os.path.dirname(
+                instance.data["files"][0]
+            )


### PR DESCRIPTION
- Add TileIndex, TilesX, TilesY, TileSuffix to HuskStandalonePluginInfo
- Implement tile job submission with tile assembly via oiiotool
- Support splitting USD renders into parallel tile grids on farm


- Requires Deadline Husk Standalone changes: https://github.com/BigRoy/HuskStandaloneSubmitter/pull/11