### PR TITLE
Add missing Department as default attribute for farm submission

### DIFF
--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -705,6 +705,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "MachineLimit": data["machine_limit"],
             "ConcurrentTasks": data["concurrent_tasks"],
             "Frames": data.get("frames", ""),
+            "Department": cls._sanitize(data.get("department", "")),
             "Group": cls._sanitize(data["group"]),
             "LimitGroups": cls._sanitize(data["limit_groups"]),
             "Pool": cls._sanitize(data["primary_pool"]),

--- a/client/ayon_deadline/lib.py
+++ b/client/ayon_deadline/lib.py
@@ -705,7 +705,7 @@ class PublishDeadlineJobInfo(DeadlineJobInfo):
             "MachineLimit": data["machine_limit"],
             "ConcurrentTasks": data["concurrent_tasks"],
             "Frames": data.get("frames", ""),
-            "Department": cls._sanitize(data.get("department", "")),
+            "Department": cls._sanitize(data.get("department") or None),
             "Group": cls._sanitize(data["group"]),
             "LimitGroups": cls._sanitize(data["limit_groups"]),
             "Pool": cls._sanitize(data["primary_pool"]),

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -215,10 +215,15 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         )
 
         job_info = instance.data["deadline"]["job_info"]
+        if job_info.Department is not None and not self.deadline_department:
+            deadline_department = job_info.Department
+        else:
+            deadline_department = self.deadline_department
+
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=batch_name,
-            Department=self.deadline_department,
+            Department=deadline_department,
             Priority=priority,
             InitialStatus=job_info.publish_job_state,
             Group=self.deadline_group,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -214,12 +214,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
-        job_info = instance.data["deadline"]["job_info"]
-        if job_info.Department is not None and not self.deadline_department:
-            deadline_department = job_info.Department
-        else:
-            deadline_department = self.deadline_department
-
+job_info = instance.data["deadline"]["job_info"]
+deadline_department = (
+    job_info.Department
+    or self.deadline_department
+    or None
+)
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=batch_name,

--- a/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
+++ b/client/ayon_deadline/plugins/publish/global/submit_publish_job.py
@@ -214,12 +214,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             context.data["ayonAddonsManager"]["deadline"]
         )
 
-job_info = instance.data["deadline"]["job_info"]
-deadline_department = (
-    job_info.Department
-    or self.deadline_department
-    or None
-)
+        job_info = instance.data["deadline"]["job_info"]
+        deadline_department = (
+            job_info.Department
+            or self.deadline_department
+            or None
+        )
         job_info = DeadlineJobInfo(
             Name=job_name,
             BatchName=batch_name,


### PR DESCRIPTION
## Changelog Description
This PR is to add missing Department data as default attribute in terms of farm submission

## Additional review information
Fixes https://github.com/ynput/ayon-deadline/issues/254

## Testing notes:
1. Create Render Instance for Farm 
2. Type your own Department in Publisher UI
3. Check on Job info in deadline, you can find the related Department listed.