### PR TITLE
Houdini : add FullVersion to PluginInfo

### DIFF
--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_cache_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_cache_deadline.py
@@ -24,6 +24,7 @@ class HoudiniPluginInfo:
     OutputDriver: str = field(default=None)
     Version: str = field(default=None)  # Mandatory for Deadline
     ProjectPath: str = field(default=None)
+    FullVersion: str = field(default=None)
 
 
 class HoudiniCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,   # noqa
@@ -86,8 +87,8 @@ class HoudiniCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
         import hou
 
         instance = self._instance
-        version = hou.applicationVersionString()
-        version = ".".join(version.split(".")[:2])
+        full_version = hou.applicationVersionString()
+        version = ".".join(full_version.split(".")[:2])
         rop = self.get_rop_node(instance)
         plugin_info = HoudiniPluginInfo(
             Build=None,
@@ -97,7 +98,8 @@ class HoudiniCacheSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
             SaveFile=True,
             OutputDriver=rop.path(),
             Version=version,
-            ProjectPath=os.path.dirname(self.scene_path)
+            FullVersion=full_version,
+            ProjectPath=os.path.dirname(self.scene_path),
         )
 
         plugin_payload = asdict(plugin_info)

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -19,6 +19,7 @@ class DeadlinePluginInfo:
     OutputDriver: str = field(default=None)
     Version: str = field(default=None)
     IgnoreInputs: bool = field(default=True)
+    FullVersion: str = field(default=None)
 
 
 @dataclass
@@ -262,7 +263,8 @@ class HoudiniSubmitDeadline(
         instance = self._instance
         context = instance.context
 
-        hou_major_minor = hou.applicationVersionString().rsplit(".", 1)[0]
+        hou_full_version = hou.applicationVersionString()
+        hou_major_minor = hou_full_version.rsplit(".", 1)[0]
 
         # Output driver to render
         if job_type == "render":
@@ -315,7 +317,8 @@ class HoudiniSubmitDeadline(
                 SceneFile=context.data["currentFile"],
                 OutputDriver=driver.path(),
                 Version=hou_major_minor,
-                IgnoreInputs=True
+                IgnoreInputs=True,
+                FullVersion=hou_full_version,
             )
 
         return asdict(plugin_info)


### PR DESCRIPTION
To make the farm run the exact Houdini build an artist submitted from, I added a
`FullVersion` key to the Houdini PluginInfo, carrying the untruncated
`hou.applicationVersionString()`, keeping, alongside the existing `Version` (truncated to major.minor (e.g. `20.5`). 

Thank you!