### PR TITLE
Use Stage metadata for rendersettings

### DIFF
--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -12,7 +12,6 @@ from ayon_core.lib import (
 )
 from ayon_deadline import abstract_submit_deadline
 
-
 @dataclass
 class DeadlinePluginInfo:
     SceneFile: str = field(default=None)
@@ -350,6 +349,7 @@ class HoudiniSubmitDeadline(
 
         rendersettings = (
             rop_node.evalParm("rendersettings")
+            or instance.data["stage"].GetMetadata("renderSettingsPrimPath")
             or "/Render/rendersettings"
         )
 

--- a/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
+++ b/client/ayon_deadline/plugins/publish/houdini/submit_houdini_render_deadline.py
@@ -12,6 +12,7 @@ from ayon_core.lib import (
 )
 from ayon_deadline import abstract_submit_deadline
 
+
 @dataclass
 class DeadlinePluginInfo:
     SceneFile: str = field(default=None)


### PR DESCRIPTION
## Changelog Description
Use stage metadata for default render settings prim before fallback to `/Render/rendersettings`
I believe if husk doesn't get a `--settings` parameter it fallbacks to `default render prim`. However, when it's given a `--settings` parameter and that prim is not in stage, it errors out.

PR is linked to ynput/ayon-houdini#420

I started looking into render pass support too (added in H21, ayon currently ignores the parameter), and i think the logic for getting render settings will likely have to change (render pass can hold info on which render settings to use). [husk](https://www.sidefx.com/docs/houdini/ref/utils/husk.html) - see `-pass`
 
But for now, this PR avoids errors on submission and is inline with ynput/ayon-houdini#420